### PR TITLE
Handle invalid spreedly response

### DIFF
--- a/lib/spreedly.rb
+++ b/lib/spreedly.rb
@@ -32,6 +32,8 @@ so we can improve it. Thanks!
 module Spreedly
   REAL = "real" # :nodoc:
 
+  class Error < Exception; end
+
   include HTTParty
   headers 'Accept' => 'text/xml'
   headers 'Content-Type' => 'text/xml'
@@ -108,6 +110,8 @@ module Spreedly
     #   Spreedly.Subscriber.create!(id, :email => email, :screen_name => screen_name)
     #   Spreedly.Subscriber.create!(id, email, screen_name, :billing_first_name => first_name)
     def self.create!(id, *args)      
+      raise Error.new "Some error."
+
       optional_attrs = args.last.is_a?(::Hash) ? args.pop : {}
       email, screen_name = args
       subscriber = {:customer_id => id, :email => email, :screen_name => screen_name}.merge(optional_attrs)
@@ -117,15 +121,15 @@ module Spreedly
 	unless result['subscriber'].nil?
 	  new(result['subscriber'])
 	else
-	  raise "Did not receive subscriber information from spreedly: #{result.inspect}"
+	  raise Error.new "Did not receive subscriber information from spreedly: #{result.inspect}"
 	end
       when '403'
-        raise "Could not create subscriber: already exists."
+        raise Error.new "Could not create subscriber: already exists."
       when '422'
         errors = [*result['errors']].collect{|e| e.last}
-        raise "Could not create subscriber: #{errors.join(', ')}"
+        raise Error.new "Could not create subscriber: #{errors.join(', ')}"
       else
-        raise "Could not create subscriber: result code #{result.code}."
+        raise Error.new "Could not create subscriber: result code #{result.code}."
       end
     end
     
@@ -156,19 +160,19 @@ module Spreedly
     def comp(quantity, units, feature_level=nil)
       params = {:duration_quantity => quantity, :duration_units => units}
       params[:feature_level] = feature_level if feature_level
-      raise "Feature level is required to comp an inactive subscriber" if !active? and !feature_level
+      raise Error.new "Feature level is required to comp an inactive subscriber" if !active? and !feature_level
       endpoint = (active? ? "complimentary_time_extensions" : "complimentary_subscriptions")
       result = Spreedly.post("/subscribers/#{id}/#{endpoint}.xml", :body => Spreedly.to_xml_params(endpoint[0..-2] => params))
       case result.code.to_s
       when /2../
       when '404'
-        raise "Could not comp subscriber: no longer exists."
+        raise Error.new "Could not comp subscriber: no longer exists."
       when '422'
-        raise "Could not comp subscriber: validation failed (#{result.body})."
+        raise Error.new "Could not comp subscriber: validation failed (#{result.body})."
       when '403'
-        raise "Could not comp subscriber: invalid comp type (#{endpoint})."
+        raise Error.new "Could not comp subscriber: invalid comp type (#{endpoint})."
       else
-        raise "Could not comp subscriber: result code #{result.code}."
+        raise Error.new "Could not comp subscriber: result code #{result.code}."
       end
     end
     
@@ -180,13 +184,13 @@ module Spreedly
       case result.code.to_s
       when /2../
       when '404'
-        raise "Could not active free trial for subscriber: subscriber or subscription plan no longer exists."
+        raise Error.new "Could not active free trial for subscriber: subscriber or subscription plan no longer exists."
       when '422'
-        raise "Could not activate free trial for subscriber: validation failed. missing subscription plan id"
+        raise Error.new "Could not activate free trial for subscriber: validation failed. missing subscription plan id"
       when '403'
-        raise "Could not activate free trial for subscriber: subscription plan either 1) isn't a free trial, 2) the subscriber is not eligible for a free trial, or 3) the subscription plan is not enabled."
+        raise Error.new "Could not activate free trial for subscriber: subscription plan either 1) isn't a free trial, 2) the subscriber is not eligible for a free trial, or 3) the subscription plan is not enabled."
       else
-        raise "Could not activate free trial for subscriber: result code #{result.code}."
+        raise Error.new "Could not activate free trial for subscriber: result code #{result.code}."
       end
     end
     

--- a/lib/spreedly/mock.rb
+++ b/lib/spreedly/mock.rb
@@ -1,10 +1,13 @@
 require 'spreedly/common'
 
+
 raise "Real Spreedly already required!" if defined?(Spreedly::REAL)
 
 module Spreedly
   MOCK = "mock"
   
+  class Error < Exception; end
+
   def self.configure(name, token)
     @site_name = name
   end
@@ -65,7 +68,7 @@ module Spreedly
       sub = new({:customer_id => id, :email => email, :screen_name => screen_name}.merge(optional_attrs))
 
       if subscribers[sub.id]
-        raise "Could not create subscriber: already exists."
+        raise Error.new "Could not create subscriber: already exists."
       end
 
       subscribers[sub.id] = sub
@@ -91,7 +94,7 @@ module Spreedly
     def initialize(params={})
       super
       if !id || id == ''
-        raise "Could not create subscriber: Customer ID can't be blank."
+        raise Error.new "Could not create subscriber: Customer ID can't be blank."
       end
     end
     
@@ -108,8 +111,8 @@ module Spreedly
     end
     
     def comp(quantity, units, feature_level=nil)
-      raise "Could not comp subscriber: no longer exists." unless self.class.find(id)
-      raise "Could not comp subscriber: validation failed." unless units && quantity
+      raise Error.new "Could not comp subscriber: no longer exists." unless self.class.find(id)
+      raise Error.new "Could not comp subscriber: validation failed." unless units && quantity
       current_active_until = (active_until || Time.now)
       @attributes[:active_until] = case units
       when 'days'
@@ -122,9 +125,9 @@ module Spreedly
     end
 
     def activate_free_trial(plan_id)
-      raise "Could not activate free trial for subscriber: validation failed. missing subscription plan id" unless plan_id
-      raise "Could not active free trial for subscriber: subscriber or subscription plan no longer exists." unless self.class.find(id) && SubscriptionPlan.find(plan_id)
-      raise "Could not activate free trial for subscriber: subscription plan either 1) isn't a free trial, 2) the subscriber is not eligible for a free trial, or 3) the subscription plan is not enabled." if (on_trial? and !eligible_for_free_trial?)
+      raise Error.new "Could not activate free trial for subscriber: validation failed. missing subscription plan id" unless plan_id
+      raise Error.new "Could not active free trial for subscriber: subscriber or subscription plan no longer exists." unless self.class.find(id) && SubscriptionPlan.find(plan_id)
+      raise Error.new "Could not activate free trial for subscriber: subscription plan either 1) isn't a free trial, 2) the subscriber is not eligible for a free trial, or 3) the subscription plan is not enabled." if (on_trial? and !eligible_for_free_trial?)
       @attributes[:on_trial] = true
       plan = SubscriptionPlan.find(plan_id)
       comp(plan.duration_quantity, plan.duration_units, plan.feature_level)
@@ -135,7 +138,7 @@ module Spreedly
     end
 
     def stop_auto_renew
-      raise "Could not stop auto renew for subscriber: subscriber does not exist." unless self.class.find(id)
+      raise Error.new "Could not stop auto renew for subscriber: subscriber does not exist." unless self.class.find(id)
       @attributes[:recurring] = false
     end
     
@@ -146,8 +149,8 @@ module Spreedly
     end
     
     def add_fee(args)
-      raise "Unprocessable Entity" unless (args.keys & [:amount, :group, :name]).size == 3
-      raise "Unprocessable Entity" unless active?
+      raise Error.new "Unprocessable Entity" unless (args.keys & [:amount, :group, :name]).size == 3
+      raise Error.new "Unprocessable Entity" unless active?
       nil
     end
   end


### PR DESCRIPTION
Spreedly can sometimes respond with a 2XX status, but not include the
'subscriber' node in the response.

I've seen this at least once in production code.
