### PR TITLE
Remove Mechanize as a runtime dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,8 +7,8 @@ hoe = Hoe.spec('spreedly') do
   developer('Nathaniel Talbott', 'nathaniel@terralien.com')
   self.rubyforge_name = 'terralien'
   self.test_globs = ["test/**/*_test.rb"]
-  self.extra_deps << ["mechanize"]
   self.extra_dev_deps << ["shoulda"]
+  self.extra_dev_deps << ["mechanize"]
 end
 
 def remove_task(*task_names)


### PR DESCRIPTION
Mechanize isn't used at runtime and pulls in a c-ext. This was preventing me from using jruby. This makes mechanize a dev dependency so tests (on mri) can still use it.
