### PR TITLE
URL Encode options passed to Spreedly#subscribe_url

### DIFF
--- a/lib/spreedly/common.rb
+++ b/lib/spreedly/common.rb
@@ -5,6 +5,7 @@ end
 
 require 'uri'
 require 'bigdecimal'
+require 'cgi'
 
 require 'spreedly/version'
 
@@ -21,7 +22,7 @@ module Spreedly
     end
 
     screen_name = options.delete(:screen_name)
-    params = %w(email first_name last_name return_url).select{|e| options[e.to_sym]}.collect{|e| "#{e}=#{options[e.to_sym]}"}.join('&')
+    params = %w(email first_name last_name return_url).select{|e| options[e.to_sym]}.collect{|e| "#{e}=#{CGI::escape(options[e.to_sym])}"}.join('&')
 
     url = "https://spreedly.com/#{site_name}/subscribers/#{id}/subscribe/#{plan}"
     url << "/#{screen_name}" if screen_name

--- a/test/spreedly_gem_test.rb
+++ b/test/spreedly_gem_test.rb
@@ -119,14 +119,16 @@ class SpreedlyGemTest < Test::Unit::TestCase
         Spreedly.subscribe_url('joe', '1', :screen_name => "Joe Bob")
       assert_equal "https://spreedly.com/#{Spreedly.site_name}/subscribers/joe/subscribe/1",
         Spreedly.subscribe_url('joe', '1')
+      assert_equal "https://spreedly.com/#{Spreedly.site_name}/subscribers/joe/subscribe/1?email=joe%2Btest%40example.com",
+        Spreedly.subscribe_url('joe', '1', :email => "joe+test@example.com")
     end
     
     should "generate a pre-populated subscribe url" do
-      assert_equal "https://spreedly.com/#{Spreedly.site_name}/subscribers/joe/subscribe/1?email=joe.bob@test.com&first_name=Joe&last_name=Bob",
+      assert_equal "https://spreedly.com/#{Spreedly.site_name}/subscribers/joe/subscribe/1?email=joe.bob%40test.com&first_name=Joe&last_name=Bob",
         Spreedly.subscribe_url('joe', '1', :email => "joe.bob@test.com", :first_name => "Joe", :last_name => "Bob")
       assert_equal "https://spreedly.com/#{Spreedly.site_name}/subscribers/joe/subscribe/1?first_name=Joe&last_name=Bob",
         Spreedly.subscribe_url('joe', '1', :first_name => "Joe", :last_name => "Bob")
-      assert_equal "https://spreedly.com/#{Spreedly.site_name}/subscribers/joe/subscribe/1?return_url=http://stuffo.example.com",
+      assert_equal "https://spreedly.com/#{Spreedly.site_name}/subscribers/joe/subscribe/1?return_url=http%3A%2F%2Fstuffo.example.com",
         Spreedly.subscribe_url('joe', '1', :return_url => 'http://stuffo.example.com')
     end
     


### PR DESCRIPTION
Hey there. I noticed while looking around that passing the email test+email@example.com to Spreedly#subscribe_url would result in the Spreedly page showing: "test email@example.com".

Included is a quick patch to URL encode the options along with updated tests.

I struggled to get the testing environment set up so I could only really run the non-mechanize tests. In case you care I have a branch where I added a basic Gemfile / .rbenv_version file to get me moving: https://github.com/dies-el/spreedly-gem/tree/bundler_rbenv

Thanks,

Andrew
