### PR TITLE
Fix failing test_add_test_receiver remote test

### DIFF
--- a/test/remote/remote_add_receiver_test.rb
+++ b/test/remote/remote_add_receiver_test.rb
@@ -25,9 +25,9 @@ class RemoteAddReceiverTest < Test::Unit::TestCase
   end
 
   def test_add_test_receiver
-    receiver = @environment.add_receiver(:test, 'http://api.example.com/post')
+    receiver = @environment.add_receiver(:test, 'http://testserver.com')
     assert_equal "test", receiver.receiver_type
-    assert_equal 'http://api.example.com/post', receiver.hostnames
+    assert_equal 'http://testserver.com', receiver.hostnames
   end
 
   # Coming soon


### PR DESCRIPTION
For some reason this test was failing with the URL of http://api.example.com/post, but a change to http://testserver.com makes it pass.  I'm assuming that changing this doesn't impact the validity of the test.  Feel free to weigh in here.