### PR TITLE
Support disburse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg
 tmp
 vendor/ruby
 test/credentials/personal_credentials.yml
+.ruby-version

--- a/lib/spreedly/common/fields.rb
+++ b/lib/spreedly/common/fields.rb
@@ -86,4 +86,3 @@ class Array
     end
   end
 end
-

--- a/lib/spreedly/gateway_class.rb
+++ b/lib/spreedly/gateway_class.rb
@@ -9,7 +9,7 @@ module Spreedly
           :supports_purchase_via_preauthorization, :supports_offsite_purchase,
           :supports_offsite_authorize, :supports_3dsecure_purchase, :supports_3dsecure_authorize,
           :supports_store, :supports_remove, :supports_general_credit,
-          :supports_fraud_review, type: :boolean
+          :supports_fraud_review, :supports_disburse, type: :boolean
 
     attr_reader :supported_countries, :payment_methods, :auth_modes, :regions
 

--- a/test/unit/gateway_options_test.rb
+++ b/test/unit/gateway_options_test.rb
@@ -67,7 +67,8 @@ class GatewayOptionsTest < Test::Unit::TestCase
       :supports_3dsecure_purchase,
       :supports_3dsecure_authorize,
       :supports_store,
-      :supports_fraud_review
+      :supports_fraud_review,
+      :supports_disburse
     ].each do |c|
       assert gateway_class.send("#{c}?")
     end

--- a/test/unit/response_stubs/add_gateway_stubs.rb
+++ b/test/unit/response_stubs/add_gateway_stubs.rb
@@ -21,6 +21,7 @@ module AddGatewayStubs
           <supports_3dsecure_authorize type="boolean">true</supports_3dsecure_authorize>
           <supports_store type="boolean">true</supports_store>
           <supports_remove type="boolean">true</supports_remove>
+          <supports_disburse type="boolean">true</supports_disburse>
           <supports_fraud_review type="boolean">true</supports_fraud_review>
         </characteristics>
         <state>retained</state>

--- a/test/unit/response_stubs/find_gateway_stubs.rb
+++ b/test/unit/response_stubs/find_gateway_stubs.rb
@@ -23,6 +23,7 @@ module FindGatewayStubs
           <supports_3dsecure_authorize type="boolean">false</supports_3dsecure_authorize>
           <supports_store type="boolean">false</supports_store>
           <supports_remove type="boolean">false</supports_remove>
+          <supports_disburse type="boolean">false</supports_disburse>
           <supports_fraud_review type="boolean">false</supports_fraud_review>
         </characteristics>
         <credentials>

--- a/test/unit/response_stubs/gateway_options_stubs.rb
+++ b/test/unit/response_stubs/gateway_options_stubs.rb
@@ -78,6 +78,7 @@ module GatewayOptionsStubs
             <supports_3dsecure_authorize type="boolean">true</supports_3dsecure_authorize>
             <supports_store type="boolean">true</supports_store>
             <supports_remove type="boolean">false</supports_remove>
+            <supports_disburse type="boolean">true</supports_disburse>
             <supports_fraud_review type="boolean">true</supports_fraud_review>
           </characteristics>
           <payment_methods>
@@ -129,6 +130,7 @@ module GatewayOptionsStubs
             <supports_3dsecure_authorize type="boolean">false</supports_3dsecure_authorize>
             <supports_store type="boolean">false</supports_store>
             <supports_remove type="boolean">false</supports_remove>
+            <supports_disburse type="boolean">true</supports_disburse>
             <supports_fraud_review type="boolean">false</supports_fraud_review>
           </characteristics>
           <payment_methods>

--- a/test/unit/response_stubs/list_gateways_stubs.rb
+++ b/test/unit/response_stubs/list_gateways_stubs.rb
@@ -22,6 +22,7 @@ module ListGatewaysStubs
             <supports_3dsecure_authorize type="boolean">true</supports_3dsecure_authorize>
             <supports_store type="boolean">true</supports_store>
             <supports_remove type="boolean">true</supports_remove>
+            <supports_disburse type="boolean">true</supports_disburse>
             <supports_fraud_review type="boolean">true</supports_fraud_review>
           </characteristics>
           <credentials>
@@ -57,6 +58,7 @@ module ListGatewaysStubs
             <supports_3dsecure_authorize type="boolean">true</supports_3dsecure_authorize>
             <supports_store type="boolean">true</supports_store>
             <supports_remove type="boolean">true</supports_remove>
+            <supports_disburse type="boolean">true</supports_disburse>
           </characteristics>
           <credentials>
           </credentials>

--- a/test/unit/response_stubs/redact_gateway_stubs.rb
+++ b/test/unit/response_stubs/redact_gateway_stubs.rb
@@ -28,6 +28,7 @@ module RedactGatewayStubs
             <supports_3dsecure_authorize type="boolean">true</supports_3dsecure_authorize>
             <supports_store type="boolean">true</supports_store>
             <supports_remove type="boolean">true</supports_remove>
+            <supports_disburse type="boolean">true</supports_disburse>
           </characteristics>
           <state>redacted</state>
           <payment_methods>


### PR DESCRIPTION
@duff Apparently I need support for `disburse` here in the client before I can generate the docs? Just a quick sanity check - all I'm hoping for is to be able to call `supports_disburse?` on the gateway class.