### PR TITLE
Add support for purchase shipping address override

### DIFF
--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -267,6 +267,7 @@ module Spreedly
 
     def add_extra_options_for_basic_ops(doc, options)
       add_gateway_specific_fields(doc, options)
+      add_shipping_address_override(doc, options)
       add_to_doc(doc, options, :order_id, :description, :ip, :merchant_name_descriptor,
                                :merchant_location_descriptor)
     end
@@ -274,6 +275,15 @@ module Spreedly
     def add_gateway_specific_fields(doc, options)
       return unless options[:gateway_specific_fields].kind_of?(Hash)
       doc << "<gateway_specific_fields>#{xml_for_hash(options[:gateway_specific_fields])}</gateway_specific_fields>"
+    end
+
+    def add_shipping_address_override(doc, options)
+      return unless options[:shipping_address].kind_of?(Hash)
+      doc.send(:shipping_address) do
+        options[:shipping_address].each do |k, v|
+          doc.send(k, v)
+        end
+      end
     end
 
     def xml_for_hash(hash)

--- a/lib/spreedly/transactions/gateway_transaction.rb
+++ b/lib/spreedly/transactions/gateway_transaction.rb
@@ -6,12 +6,14 @@ module Spreedly
     field :merchant_name_descriptor, :merchant_location_descriptor
     field :on_test_gateway, type: :boolean
 
-    attr_reader :response, :gateway_specific_fields
+    attr_reader :response, :gateway_specific_fields, :shipping_address
 
     def initialize(xml_doc)
       super
       response_xml_doc = xml_doc.at_xpath('.//response')
+      shipping_address_xml_doc = xml_doc.at_xpath('.//shipping_address')
       @response = response_xml_doc ? Response.new(response_xml_doc) : nil
+      @shipping_address = shipping_address_xml_doc ? ShippingAddress.new(shipping_address_xml_doc) : nil
       @gateway_specific_fields = parse_gateway_specific_fields(xml_doc)
     end
 
@@ -47,4 +49,14 @@ module Spreedly
 
   end
 
+  class ShippingAddress
+    include Fields
+
+    field :name, :address1, :address2, :city, :state, :zip, :country, :phone_number
+
+    def initialize(xml_doc)
+      initialize_fields(xml_doc)
+    end
+
+  end
 end

--- a/test/unit/purchase_test.rb
+++ b/test/unit/purchase_test.rb
@@ -43,6 +43,15 @@ class PurchaseTest < Test::Unit::TestCase
     assert !t.response.cancelled
     assert_equal Time.parse('2013-07-31T19:46:26Z'), t.response.created_at
     assert_equal Time.parse('2013-07-31T19:46:27Z'), t.response.updated_at
+
+    assert_equal '', t.shipping_address.name
+    assert_equal '', t.shipping_address.address1
+    assert_equal '', t.shipping_address.address2
+    assert_equal '', t.shipping_address.city
+    assert_equal '', t.shipping_address.state
+    assert_equal '', t.shipping_address.zip
+    assert_equal '', t.shipping_address.country
+    assert_equal '', t.shipping_address.phone_number
   end
 
   def test_failed_purchase
@@ -55,6 +64,19 @@ class PurchaseTest < Test::Unit::TestCase
     assert_equal 'gateway_processing_failed', t.state
 
     assert_equal 'The eagle is dead Jim.', t.response.error_detail
+  end
+
+  def test_successful_purchase_with_shipping_address_override
+    t = purchase_using(successful_purchase_with_shipping_address_override_response)
+
+    assert_equal 'John Doe', t.shipping_address.name
+    assert_equal '123 Main St.', t.shipping_address.address1
+    assert_equal 'Unit 1', t.shipping_address.address2
+    assert_equal 'Acme', t.shipping_address.city
+    assert_equal 'Corp', t.shipping_address.state
+    assert_equal '45678', t.shipping_address.zip
+    assert_equal 'USA', t.shipping_address.country
+    assert_equal '123-456-7890', t.shipping_address.phone_number
   end
 
   def test_request_body_params

--- a/test/unit/response_stubs/purchase_stubs.rb
+++ b/test/unit/response_stubs/purchase_stubs.rb
@@ -22,6 +22,16 @@ module PurchaseStubs
         <message key="messages.transaction_succeeded">Succeeded!</message>
         <gateway_token>YOaCn5a9xRaBTGgmGAWbkgWUuqv</gateway_token>
         <gateway_transaction_id>44</gateway_transaction_id>
+        <shipping_address>
+          <name nil="true"/>
+          <address1 nil="true"/>
+          <address2 nil="true"/>
+          <city nil="true"/>
+          <state nil="true"/>
+          <zip nil="true"/>
+          <country nil="true"/>
+          <phone_number nil="true"//>
+        </shipping_address>
         <response>
           <success type="boolean">true</success>
           <message>Successful purchase</message>
@@ -73,6 +83,88 @@ module PurchaseStubs
     XML
   end
 
+  def successful_purchase_with_shipping_address_override_response
+    StubResponse.succeeded <<-XML
+      <transaction>
+        <amount type="integer">144</amount>
+        <on_test_gateway type="boolean">true</on_test_gateway>
+        <created_at type="datetime">2013-07-31T19:46:26Z</created_at>
+        <updated_at type="datetime">2013-07-31T19:46:32Z</updated_at>
+        <currency_code>USD</currency_code>
+        <succeeded type="boolean">true</succeeded>
+        <state>succeeded</state>
+        <token>Btcyks35m4JLSNOs9ymJoNQLjeX</token>
+        <transaction_type>Purchase</transaction_type>
+        <order_id>187A</order_id>
+        <ip nil="true"/>
+        <description>4 Shardblades</description>
+        <merchant_name_descriptor nil="true"/>
+        <merchant_location_descriptor nil="true"/>
+        <gateway_specific_fields nil="true"/>
+        <gateway_specific_response_fields nil="true"/>
+        <message key="messages.transaction_succeeded">Succeeded!</message>
+        <gateway_token>YOaCn5a9xRaBTGgmGAWbkgWUuqv</gateway_token>
+        <gateway_transaction_id>44</gateway_transaction_id>
+        <shipping_address>
+          <name>John Doe</name>
+          <address1>123 Main St.</address1>
+          <address2>Unit 1</address2>
+          <city>Acme</city>
+          <state>Corp</state>
+          <zip>45678</zip>
+          <country>USA</country>
+          <phone_number>123-456-7890</phone_number>
+        </shipping_address>
+        <response>
+          <success type="boolean">true</success>
+          <message>Successful purchase</message>
+          <avs_code>22</avs_code>
+          <avs_message nil="true">I will be back</avs_message>
+          <cvv_code>31</cvv_code>
+          <cvv_message nil="true">Rutabaga</cvv_message>
+          <pending type="boolean">false</pending>
+          <fraud_review type="boolean">false</fraud_review>
+          <error_code>899</error_code>
+          <error_detail nil="true">The eagle lives!</error_detail>
+          <cancelled type="boolean">false</cancelled>
+          <created_at type="datetime">2013-07-31T19:46:26Z</created_at>
+          <updated_at type="datetime">2013-07-31T19:46:27Z</updated_at>
+        </response>
+        <payment_method>
+          <token>8xXXIPGXTaPXysDA5OUpgnjTEjK</token>
+          <created_at type="datetime">2013-07-31T19:46:25Z</created_at>
+          <updated_at type="datetime">2013-07-31T19:46:26Z</updated_at>
+          <email>perrin@wot.com</email>
+          <data nil="true"/>
+          <storage_state>retained</storage_state>
+          <last_four_digits>4444</last_four_digits>
+          <first_six_digits>411111</first_six_digits>
+          <card_type>master</card_type>
+          <first_name>Perrin</first_name>
+          <last_name>Aybara</last_name>
+          <month type="integer">1</month>
+          <year type="integer">2019</year>
+          <address1 nil="true"/>
+          <address2 nil="true"/>
+          <city nil="true"/>
+          <state nil="true"/>
+          <zip nil="true"/>
+          <country nil="true"/>
+          <phone_number nil="true"/>
+          <company>Acme</company>
+          <full_name>Perrin Aybara</full_name>
+          <payment_method_type>credit_card</payment_method_type>
+          <eligible_for_card_updater type="boolean">true</eligible_for_card_updater>
+          <errors>
+          </errors>
+          <verification_value></verification_value>
+          <number>XXXX-XXXX-XXXX-4444</number>
+        </payment_method>
+        <api_urls>
+        </api_urls>
+      </transaction>
+    XML
+  end
   def failed_purchase_response
     StubResponse.failed <<-XML
       <transaction>


### PR DESCRIPTION
@duff, this adds support for a `shipping_address` option to purchase transactions as stated in the docs: 

https://docs.spreedly.com/guides/using-payment-methods/#adding-transaction-details

Let me know if you have any thoughts/questions/concerns.