### PR TITLE
Fix purchase_on_gateway for offsite payments

### DIFF
--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -269,7 +269,7 @@ module Spreedly
       add_gateway_specific_fields(doc, options)
       add_shipping_address_override(doc, options)
       add_to_doc(doc, options, :order_id, :description, :ip, :email, :merchant_name_descriptor,
-                               :merchant_location_descriptor)
+                               :merchant_location_descriptor, :redirect_url, :callback_url)
     end
 
     def add_gateway_specific_fields(doc, options)


### PR DESCRIPTION
Add redirect_url and callback_url to `add_extra_options_for_basic_ops` necessary to purchase_on_gateway for offsite payments.