### PR TITLE
Add options for store_on_gateway

### DIFF
--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -96,8 +96,8 @@ module Spreedly
       Gateway.new_list_from(xml_doc)
     end
 
-    def store_on_gateway(gateway_token, payment_method_token)
-      body = store_body(payment_method_token)
+    def store_on_gateway(gateway_token, payment_method_token, options = {})
+      body = store_body(payment_method_token, options)
       api_post(store_url(gateway_token), body)
     end
 
@@ -211,9 +211,10 @@ module Spreedly
       end
     end
 
-    def store_body(payment_method_token)
+    def store_body(payment_method_token, options)
       build_xml_request('transaction') do |doc|
         doc.payment_method_token(payment_method_token)
+        add_gateway_specific_fields(doc, options)
       end
     end
 


### PR DESCRIPTION
In order to be able to call https://docs.spreedly.com/payment-gateways/stripe/#stripe-customer-id we need to pass gateway specific options.