### PR TITLE
Add method to re-cache sensitive data using direct API call

### DIFF
--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -70,6 +70,12 @@ module Spreedly
       Transaction.new_from(xml_doc)
     end
 
+    def recache_sensitive_data(payment_method_token, options = {})
+      body = recache_sensitive_data_body(options)
+      xml_doc = ssl_put(recache_sensitive_data_url(payment_method_token), body, headers)
+      Transaction.new_from(xml_doc)
+    end
+
     def redact_payment_method(payment_method_token, options = {})
       body = redact_payment_method_body(options)
       xml_doc = ssl_put(redact_payment_method_url(payment_method_token), body, headers)
@@ -244,6 +250,12 @@ module Spreedly
         add_to_doc(doc, options, :email, :month, :full_name, :first_name, :last_name, :year,
                    :address1, :address2, :city, :state, :zip, :country, :phone_number,
                    :eligible_for_card_updater)
+      end
+    end
+
+    def recache_sensitive_data_body(options)
+      build_xml_request('payment_method') do |doc|
+        add_to_doc(doc, options, *options.keys)
       end
     end
 

--- a/lib/spreedly/urls.rb
+++ b/lib/spreedly/urls.rb
@@ -46,6 +46,10 @@ module Spreedly
       "#{base_url}/v1/payment_methods/#{payment_method_token}/retain.xml"
     end
 
+    def recache_sensitive_data_url(receiver_token)
+      "#{base_url}/v1/payment_methods/#{receiver_token}/recache.xml"
+    end
+
     def redact_payment_method_url(payment_method_token)
       "#{base_url}/v1/payment_methods/#{payment_method_token}/redact.xml"
     end

--- a/test/remote/remote_recache_sensitive_data_test.rb
+++ b/test/remote/remote_recache_sensitive_data_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class RemoteRecacheSensitiveDataTest < Test::Unit::TestCase
+
+  def setup
+    @environment = Spreedly::Environment.new(remote_test_environment_key, remote_test_access_secret)
+  end
+
+  def test_recache_failed_verification_value
+    card = create_card_on(@environment)
+    result = @environment.recache_sensitive_data(card.token, wrong_test_data)
+
+    assert_kind_of(Spreedly::RecacheSensitiveData, result)
+    assert_equal true, result.succeeded
+    assert_equal '', result.payment_method.verification_value
+  end
+
+  def test_recache_successful_verification_value
+    card = create_card_on(@environment)
+    result = @environment.recache_sensitive_data(card.token, test_data)
+
+    assert_kind_of(Spreedly::RecacheSensitiveData, result)
+    assert_equal true, result.succeeded
+    assert_equal 'XXX', result.payment_method.verification_value
+  end
+
+  private
+  def test_data(options = {})
+    {
+      credit_card: {
+        verification_value: 123
+      }
+    }.merge(options)
+  end
+
+  def wrong_test_data(options = {})
+    {
+      credit_card: {
+        wrong_key_for_verification_value: 123
+      }
+    }.merge(options)
+  end
+
+end


### PR DESCRIPTION
This method is needed when trying to use token + CVV on gateways that require to pass CVV on every transaction.