### PR TITLE
Allow a description to be passed to add_gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ gateway = env.add_gateway(:test)
 gateway.token     # => "DnbEJaaY2egcVkCvg3s8qT38xgt"
 ```
 
+You can even add a description for the gateway:
+
+``` ruby
+gateway = env.add_gateway(:test, description: "My Incredibly Awesome Test Gateway")
+gateway.token     # => "DnbEJaaY2egcVkCvg3s8qT38xgt"
+```
 
 #### Add a payment method
 Need a payment method token to try things out?  With Spreedly it's pretty straightforward to use a
@@ -257,7 +263,7 @@ env.update_credit_card(credit_card_token, first_name: 'JimBob', last_name: 'Jone
 #### Adding other types of gateways
 
 ``` ruby
-gateway = env.add_gateway(:paypal, mode: 'delegate', email: 'fred@example.com')
+gateway = env.add_gateway(:paypal, credentials: { mode: 'delegate', email: 'fred@example.com'})
 gateway.token     # => "2nQEJaaY3egcVkCvg2s9qT37xrb"
 ```
 

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -110,8 +110,9 @@ module Spreedly
       self.new("", "").gateway_options
     end
 
-    def add_gateway(gateway_type, credentials = {})
-      body = add_gateway_body(gateway_type, credentials)
+    def add_gateway(gateway_type, options = {})
+      credentials = options[:credentials] || {}
+      body = add_gateway_body(gateway_type, options[:description], credentials)
       xml_doc = ssl_post(add_gateway_url, body, headers)
       Gateway.new(xml_doc)
     end
@@ -196,9 +197,10 @@ module Spreedly
       end
     end
 
-    def add_gateway_body(gateway_type, credentials)
+    def add_gateway_body(gateway_type, description, credentials)
       build_xml_request('gateway') do |doc|
         doc.gateway_type gateway_type
+        doc.description description
         add_to_doc(doc, credentials, *credentials.keys)
       end
     end

--- a/lib/spreedly/gateway.rb
+++ b/lib/spreedly/gateway.rb
@@ -3,7 +3,7 @@ module Spreedly
 
   class Gateway < Model
 
-    field :gateway_type, :state, :name
+    field :gateway_type, :description, :state, :name
     attr_reader :credentials
 
     def initialize(xml_doc)

--- a/test/unit/add_gateway_test.rb
+++ b/test/unit/add_gateway_test.rb
@@ -12,9 +12,10 @@ class AddGatewayTest < Test::Unit::TestCase
   def test_add_test_gateway
     @environment.stubs(:raw_ssl_request).returns(successful_add_test_gateway_response)
 
-    gateway = @environment.add_gateway(:test)
+    gateway = @environment.add_gateway(:test, description: "Test Gateway")
     assert_equal("4dFb93AiRDEJ18MS9xDGMyu22uO", gateway.token)
     assert_equal("test", gateway.gateway_type)
+    assert_equal("Test Gateway", gateway.description)
     assert_equal("retained", gateway.state)
     assert_equal("Test", gateway.name)
     assert_equal({}, gateway.credentials)
@@ -22,12 +23,21 @@ class AddGatewayTest < Test::Unit::TestCase
 
   def test_request_body_params
     body = get_request_body(successful_add_test_gateway_response) do
-      @environment.add_gateway(:wirecard, username: "TheUserName", password: "ThePassword", business_case_signature: "TheSig")
+      @environment.add_gateway(
+        :wirecard,
+        description: "Test Gateway",
+        credentials: {
+          username: "TheUserName",
+          password: "ThePassword",
+          business_case_signature: "TheSig"
+        }
+      )
     end
 
     gateway = body.xpath('./gateway')
     assert_xpaths_in gateway,
       [ './gateway_type', 'wirecard' ],
+      [ './description', 'Test Gateway' ],
       [ './username', 'TheUserName' ],
       [ './password', 'ThePassword' ],
       [ './business_case_signature', 'TheSig']

--- a/test/unit/response_stubs/add_gateway_stubs.rb
+++ b/test/unit/response_stubs/add_gateway_stubs.rb
@@ -6,6 +6,7 @@ module AddGatewayStubs
         <token>4dFb93AiRDEJ18MS9xDGMyu22uO</token>
         <gateway_type>test</gateway_type>
         <name>Test</name>
+        <description>Test Gateway</description>
         <characteristics>
           <supports_purchase type="boolean">true</supports_purchase>
           <supports_authorize type="boolean">true</supports_authorize>

--- a/test/unit/response_stubs/find_gateway_stubs.rb
+++ b/test/unit/response_stubs/find_gateway_stubs.rb
@@ -6,6 +6,7 @@ module FindGatewayStubs
         <token>5YqAdCL5AaxdbDdo1yZCkB4r74p</token>
         <gateway_type>wirecard</gateway_type>
         <name>Wirecard</name>
+        <description>Wirecard Gateway</description>
         <username>username</username>
         <business_case_signature>signature</business_case_signature>
         <characteristics>

--- a/test/unit/response_stubs/list_gateways_stubs.rb
+++ b/test/unit/response_stubs/list_gateways_stubs.rb
@@ -7,6 +7,7 @@ module ListGatewaysStubs
           <token>OJUFe5ZR6pFfL4i4ZGVmvGWkZUY</token>
           <gateway_type>test</gateway_type>
           <name>Spreedly Test</name>
+          <description>Spreedly Test Gateway</description>
           <characteristics>
             <supports_purchase type="boolean">true</supports_purchase>
             <supports_authorize type="boolean">true</supports_authorize>
@@ -43,6 +44,7 @@ module ListGatewaysStubs
           <token>52wqOssuKZSXEYde30AGTG6xl8v</token>
           <gateway_type>test</gateway_type>
           <name>Spreedly Test</name>
+          <description>Spreedly Test Gateway</description>
           <characteristics>
             <supports_purchase type="boolean">true</supports_purchase>
             <supports_authorize type="boolean">true</supports_authorize>

--- a/test/unit/response_stubs/redact_gateway_stubs.rb
+++ b/test/unit/response_stubs/redact_gateway_stubs.rb
@@ -13,6 +13,7 @@ module RedactGatewayStubs
           <token>8zy49qcEUigjYbpPKCjlhDzUqJ</token>
           <gateway_type>test</gateway_type>
           <name>Spreedly Test</name>
+          <description>Spreedly Test Gateway</description>
           <characteristics>
             <supports_purchase type="boolean">true</supports_purchase>
             <supports_authorize type="boolean">true</supports_authorize>


### PR DESCRIPTION
This allows one to pass a description to `add_gateway`, just like the API allows.
