### PR TITLE
Fix add_credit_card examples to use payment_method instead of card

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2019, last_
 transaction = env.add_credit_card(options)
 
 transaction.token                 # => "2nQEJaaY3egcVkCvg2s9qT37xrb"
-transaction.card.token            # => "7rbEKaaY0egcBkCrg2sbqTo7Qrb"
-transaction.card.last_name        # => "Aybara"
+transaction.payment_method.token            # => "7rbEKaaY0egcBkCrg2sbqTo7Qrb"
+transaction.payment_method.last_name        # => "Aybara"
 ```
 
 You can also retain the card immediately like so:
@@ -290,7 +290,7 @@ email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2019, last_
 }
 transaction = env.add_credit_card(options)
 
-transaction.card.storage_state    # => "retained"
+transaction.payment_method.storage_state    # => "retained"
 ```
 
 And you might want to specify a number of other details like the billing address, etc:
@@ -302,7 +302,7 @@ email: 'leavenworth@free.com', number: '9555555555554444', month: 3, year: 2021,
 
 transaction = env.add_credit_card(options)
 
-transaction.card.last_name      # => "Smedry"
+transaction.payment_method.last_name      # => "Smedry"
 
 ```
 


### PR DESCRIPTION
I think there is changes in attributes name and not reflected in readme file.