### PR TITLE
Add #receiver_options method to Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,14 @@ You can get the full list of supported gateways like so:
 env.gateway_options
 ```
 
+#### Getting meta information about the supported payment method distribution receivers
+
+You can get the full list of supported receivers like so:
+
+``` ruby
+env.receiver_options
+```
+
 
 ## Error Handling
 

--- a/lib/spreedly.rb
+++ b/lib/spreedly.rb
@@ -32,6 +32,7 @@ require 'spreedly/transactions/store'
 require 'spreedly/gateway'
 require 'spreedly/receiver'
 require 'spreedly/gateway_class'
+require 'spreedly/receiver_class'
 require 'spreedly/error'
 
 module Spreedly

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -110,6 +110,15 @@ module Spreedly
       self.new("", "").gateway_options
     end
 
+    def receiver_options
+      xml_doc = ssl_get(receiver_options_url, headers)
+      ReceiverClass.new_list_from(xml_doc)
+    end
+
+    def self.receiver_options
+      self.new("", "").receiver_options
+    end
+
     def add_gateway(gateway_type, credentials = {})
       body = add_gateway_body(gateway_type, credentials)
       xml_doc = ssl_post(add_gateway_url, body, headers)

--- a/lib/spreedly/receiver_class.rb
+++ b/lib/spreedly/receiver_class.rb
@@ -1,0 +1,21 @@
+module Spreedly
+
+  class ReceiverClass
+    include Fields
+
+    field :receiver_type, :hostnames, :name, :company_name
+
+    def initialize(xml_doc)
+      initialize_fields(xml_doc)
+    end
+
+    def self.new_list_from(xml_doc)
+      receivers = xml_doc.xpath('.//receivers/receiver')
+      receivers.map do |each|
+        self.new(each)
+      end
+    end
+
+  end
+
+end

--- a/lib/spreedly/urls.rb
+++ b/lib/spreedly/urls.rb
@@ -83,6 +83,10 @@ module Spreedly
       "#{base_url}/v1/gateways.xml"
     end
 
+    def receiver_options_url
+      "#{base_url}/v1/receivers_options.xml"
+    end
+
     def add_receiver_url
       "#{base_url}/v1/receivers.xml"
     end

--- a/test/remote/remote_find_transaction_test.rb
+++ b/test/remote/remote_find_transaction_test.rb
@@ -13,7 +13,7 @@ class RemoteFindTransactionTest < Test::Unit::TestCase
   end
 
   def test_transaction_not_found
-    assert_raise_with_message(Spreedly::NotFoundError, "Unable to find the transaction SomeUnknownToken.") do
+    assert_raise(Spreedly::NotFoundError) do
        @environment.find_transaction("SomeUnknownToken")
     end
   end

--- a/test/remote/remote_find_transcript_test.rb
+++ b/test/remote/remote_find_transcript_test.rb
@@ -13,7 +13,7 @@ class RemoteFindTranscriptTest < Test::Unit::TestCase
   end
 
   def test_transaction_not_found
-    assert_raise_with_message(Spreedly::NotFoundError, "Unable to find the transaction SomeUnknownToken.") do
+    assert_raise(Spreedly::NotFoundError) do
        @environment.find_transcript("SomeUnknownToken")
     end
   end

--- a/test/remote/remote_receiver_options_test.rb
+++ b/test/remote/remote_receiver_options_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class RemoteReceiverOptionsTest < Test::Unit::TestCase
+
+  def setup
+    @environment = Spreedly::Environment.new(remote_test_environment_key, remote_test_access_secret)
+  end
+
+  def test_successfully_get_options
+    receiver_classes = @environment.receiver_options
+    ace = receiver_classes.select { |each| each.name == "Acerentacar Receiver" }.first
+    assert_equal "https://ota.acerentacar.com", ace.hostnames
+    assert_equal "Ace Rent a Car", ace.company_name
+    assert_equal "ace_rent_a_car_receiver", ace.receiver_type
+  end
+
+end
+

--- a/test/unit/receiver_options_test.rb
+++ b/test/unit/receiver_options_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+require 'unit/response_stubs/receiver_options_stubs'
+
+class ReceiverOptionsTest < Test::Unit::TestCase
+
+  include ReceiverOptionsStubs
+
+  def setup
+    @environment = Spreedly::Environment.new("key", "secret")
+  end
+
+  def test_successful_receiver_options
+    @environment.stubs(:raw_ssl_request).returns(successful_receiver_options_response)
+    list = @environment.receiver_options
+
+    assert_kind_of(Array, list)
+    assert_equal 2, list.size
+
+    assert_equal 'test', list.first.receiver_type
+    assert_equal 'Api', list.first.name
+    assert_equal "http://api.example.com/post", list.first.hostnames
+    assert_equal "The Example API", list.first.company_name
+    assert_equal 'test', list.last.receiver_type
+    assert_equal 'Funny', list.last.name
+    assert_equal "http://funny.pretend.example.com", list.last.hostnames
+    assert_equal "Funny Pretend", list.last.company_name
+    assert_kind_of Spreedly::ReceiverClass, list.first
+    assert_kind_of Spreedly::ReceiverClass, list.last
+  end
+
+end

--- a/test/unit/response_stubs/receiver_options_stubs.rb
+++ b/test/unit/response_stubs/receiver_options_stubs.rb
@@ -1,0 +1,22 @@
+module ReceiverOptionsStubs
+
+  def successful_receiver_options_response
+    StubResponse.succeeded <<-XML
+      <receivers>
+        <receiver>
+          <name>Api</name>
+          <receiver_type>test</receiver_type>
+          <hostnames>http://api.example.com/post</hostnames>
+          <company_name>The Example API</company>
+        </receiver>
+        <receiver>
+          <name>Funny</name>
+          <receiver_type>test</receiver_type>
+          <hostnames>http://funny.pretend.example.com</hostnames>
+          <company_name>Funny Pretend</company>
+        </receiver>
+      </receivers>
+    XML
+  end
+
+end


### PR DESCRIPTION
Adds the url, class, environment method, tests, stubs,
and documentation for a #receiver_options method to
match the new API.

Pertains to spreedly/docs#194

@rwdaigle, please check out when you have a moment.