### PR TITLE
Handle expected fields missing in the response

### DIFF
--- a/lib/spreedly/common/fields.rb
+++ b/lib/spreedly/common/fields.rb
@@ -7,8 +7,11 @@ module Spreedly
 
     def initialize_fields(xml_doc)
       self.class.fields.each do |field|
-        value = xml_doc.at_xpath(".//#{field}").inner_html.strip
-        instance_variable_set("@#{field}", value)
+        node = xml_doc.at_xpath(".//#{field}")
+        if node 
+          value = node.inner_html.strip
+          instance_variable_set("@#{field}", value)
+        end
       end
     end
 

--- a/test/remote/remote_gateway_options_test.rb
+++ b/test/remote/remote_gateway_options_test.rb
@@ -10,7 +10,7 @@ class RemoteGatewayOptionsTest < Test::Unit::TestCase
     gateway_classes = @environment.gateway_options
     braintree = gateway_classes.select { |each| each.name == "Braintree" }.first
     assert_equal "http://www.braintreepaymentsolutions.com/", braintree.homepage
-    assert_equal %w(credit_card third_party_token apple_pay), braintree.payment_methods
+    assert_equal %w(credit_card third_party_token apple_pay android_pay), braintree.payment_methods
     assert_equal %w(asia_pacific europe north_america), braintree.regions
     assert_equal %w(orange blue), braintree.auth_modes.map { |e| e.auth_mode_type }
     assert_equal %w(login password), braintree.auth_modes.first.credentials.map { |e| e.name }

--- a/test/remote/remote_receiver_options_test.rb
+++ b/test/remote/remote_receiver_options_test.rb
@@ -11,7 +11,7 @@ class RemoteReceiverOptionsTest < Test::Unit::TestCase
     ace = receiver_classes.select { |each| each.name == "Acerentacar Receiver" }.first
     assert_equal "https://ota.acerentacar.com", ace.hostnames
     assert_equal "Ace Rent a Car", ace.company_name
-    assert_equal "ace_rent_a_car_receiver", ace.receiver_type
+    assert_equal "ace_rent_a_car", ace.receiver_type
   end
 
 end

--- a/test/unit/add_credit_card_test.rb
+++ b/test/unit/add_credit_card_test.rb
@@ -25,6 +25,8 @@ class AddCreditCreditCardTest < Test::Unit::TestCase
     assert_equal "AXaBXfVUqhaGMg8ytf8isiMAAL9", t.payment_method.token
     assert_equal "Eland Venture", t.payment_method.full_name
     assert_equal "Don't test everything here, since find_payment_method tests it all.", t.payment_method.data
+
+    assert t.payment_method.eligible_for_card_updater
   end
 
   def test_request_body_params
@@ -52,6 +54,55 @@ class AddCreditCreditCardTest < Test::Unit::TestCase
       [ './zip', '1122' ],
       [ './country', 'Free Kingdoms' ],
       [ './phone_number', '81Ab' ]
+  end
+
+  def test_successful_add_credit_card_without_fields_in_response
+    t = add_card_using(successful_add_credit_card_partial_response)
+
+    assert_kind_of(Spreedly::AddPaymentMethod, t)
+    assert_kind_of(Spreedly::CreditCard, t.payment_method)
+
+    assert_equal '6wxjN6HcDik8e3mAhBaaoVGSImH', t.token
+    assert !t.retained?
+    assert t.succeeded?
+    assert_equal Time.parse("2013-08-02T18:04:45Z"), t.created_at
+    assert_equal Time.parse("2013-08-02T18:04:45Z"), t.updated_at
+    assert_equal 'Succeeded!', t.message
+
+    assert_equal "AXaBXfVUqhaGMg8ytf8isiMAAL9", t.payment_method.token
+    assert_equal "Don't test everything here, since find_payment_method tests it all.", t.payment_method.data
+
+    assert_nil t.payment_method.full_name
+    assert_nil t.payment_method.address1
+    assert_nil t.payment_method.address2
+    assert_nil t.payment_method.city
+    assert_nil t.payment_method.state
+    assert_nil t.payment_method.zip
+    assert_nil t.payment_method.eligible_for_card_updater
+  end
+
+  def test_request_body_params_without_fields_in_response
+    body = get_request_body(successful_add_credit_card_partial_response) do
+      @environment.add_credit_card(full_card_details)
+    end
+
+    payment_method = body.xpath('./payment_method')
+    assert_xpaths_in payment_method, [ './retained', 'true' ]
+
+    card = body.xpath('./payment_method/credit_card')
+    assert_xpaths_in card,
+      [ './first_name', 'Leavenworth' ],
+      [ './last_name', 'Smedry' ],
+      [ './number', '9555555555554444' ],
+      [ './month', '3' ],
+      [ './year', '2021' ]
+
+    assert_nil body.at_xpath('./payment_method/address1')
+    assert_nil body.at_xpath('./payment_method/address2')
+    assert_nil body.at_xpath('./payment_method/city')
+    assert_nil body.at_xpath('./payment_method/state')
+    assert_nil body.at_xpath('./payment_method/zip')
+    assert_nil body.at_xpath('./payment_method/eligible_for_card_updater')
   end
 
   private

--- a/test/unit/fields_test.rb
+++ b/test/unit/fields_test.rb
@@ -4,15 +4,15 @@ class FieldsTest < Test::Unit::TestCase
 
   class ModelWithFields
     include Spreedly::Fields
-    field :message, :amount, :on_test_gateway, :updated_at, :succeeded
+    field :message, :amount, :on_test_gateway, :updated_at, :succeeded, :field_not_in_response
   end
 
   class ModelWithTypedFields
     include Spreedly::Fields
-    field :message
-    field :succeeded, :on_test_gateway, type: :boolean
-    field :amount, type: :integer
-    field :updated_at, type: :date_time
+    field :message, :string_field_not_in_response
+    field :succeeded, :on_test_gateway, :boolean_field_not_in_response, type: :boolean
+    field :amount, :integer_field_not_in_response, type: :integer
+    field :updated_at, :date_time_field_not_in_response, type: :date_time
   end
 
   def setup
@@ -26,6 +26,7 @@ class FieldsTest < Test::Unit::TestCase
     assert_nil @model.on_test_gateway
     assert_nil @model.updated_at
     assert_nil @model.succeeded
+    assert_nil @model.field_not_in_response
   end
 
   def test_defaults_to_nil_for_typed_fields
@@ -36,6 +37,10 @@ class FieldsTest < Test::Unit::TestCase
     assert_nil @typed_model.updated_at
     assert_nil @typed_model.succeeded
     assert_nil @typed_model.succeeded?
+    assert_nil @typed_model.string_field_not_in_response
+    assert_nil @typed_model.boolean_field_not_in_response
+    assert_nil @typed_model.integer_field_not_in_response
+    assert_nil @typed_model.date_time_field_not_in_response
   end
 
   def test_initialize_fields_for_strings
@@ -45,6 +50,7 @@ class FieldsTest < Test::Unit::TestCase
     assert_equal "true", @model.on_test_gateway
     assert_equal "2013-07-31T19:51:57Z", @model.updated_at
     assert_equal "false", @model.succeeded
+    assert_nil @model.field_not_in_response
   end
 
   def test_initialize_fields_for_typed_fields
@@ -56,8 +62,12 @@ class FieldsTest < Test::Unit::TestCase
     assert_equal Time.parse("2013-07-31T19:51:57Z"), @typed_model.updated_at
     assert_equal false, @typed_model.succeeded
     assert_equal false, @typed_model.succeeded?
+    
+    assert_nil @typed_model.string_field_not_in_response
+    assert_nil @typed_model.boolean_field_not_in_response
+    assert_nil @typed_model.integer_field_not_in_response
+    assert_nil @typed_model.date_time_field_not_in_response
   end
-
 
   private
   def xml

--- a/test/unit/response_stubs/add_credit_card_stubs.rb
+++ b/test/unit/response_stubs/add_credit_card_stubs.rb
@@ -35,7 +35,6 @@ module AddCreditCardStubs
           <full_name>Eland Venture</full_name>
           <eligible_for_card_updater type="boolean">true</eligible_for_card_updater>
           <payment_method_type>credit_card</payment_method_type>
-          <eligible_for_card_updater type="boolean">true</eligible_for_card_updater>
           <errors>
           </errors>
           <verification_value></verification_value>
@@ -46,4 +45,38 @@ module AddCreditCardStubs
       XML
   end
 
+  def successful_add_credit_card_partial_response
+    StubResponse.succeeded <<-XML
+      <transaction>
+        <token>6wxjN6HcDik8e3mAhBaaoVGSImH</token>
+        <created_at type="datetime">2013-08-02T18:04:45Z</created_at>
+        <updated_at type="datetime">2013-08-02T18:04:45Z</updated_at>
+        <succeeded type="boolean">true</succeeded>
+        <transaction_type>AddPaymentMethod</transaction_type>
+        <retained type="boolean">false</retained>
+        <message key="messages.transaction_succeeded">Succeeded!</message>
+        <payment_method>
+          <token>AXaBXfVUqhaGMg8ytf8isiMAAL9</token>
+          <created_at type="datetime">2013-08-02T18:04:45Z</created_at>
+          <updated_at type="datetime">2013-08-02T18:04:45Z</updated_at>
+          <email>ellend@mistborn.com</email>
+          <data>Don't test everything here, since find_payment_method tests it all.</data>
+          <storage_state>cached</storage_state>
+          <last_four_digits>4942</last_four_digits>
+          <first_six_digits>411111</first_six_digits>
+          <card_type>master</card_type>
+          <first_name>Eland</first_name>
+          <last_name>Venture</last_name>
+          <month type="integer">1</month>
+          <year type="integer">2019</year>
+          <payment_method_type>credit_card</payment_method_type>
+          <errors>
+          </errors>
+          <verification_value></verification_value>
+          <fingerprint>ac5579920013cc571e506805f1c8f3220eff</fingerprint>
+          <number>XXXX-XXXX-XXXX-4942</number>
+        </payment_method>
+      </transaction>
+      XML
+  end
 end


### PR DESCRIPTION
An incident occurred where we had removed a field from the response in
`spreedly/core` but the gem was not updated to reflect the change.

This resulted in causing customers using the Spreedly gem to experience a
client side error and duplicate transactions, even though we were
successfully processing transactions at the gateway.

The update will ignore parsing fields that are defined but not
in the response and they will default to nil.

However, the response and parsing are tightly coupled in
several other cases and we will need to evaluate how to/if we should handle
those differently.

Fix/update broken remote tests.

Closes #69.

@spreedly/product-dev 