### PR TITLE
Remove disbursement support

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Next Version
-
+* Removes support for disbursements [bpollack]
 
 ## 2.0.16
 * Support disburse [rwdaigle]

--- a/lib/spreedly/gateway_class.rb
+++ b/lib/spreedly/gateway_class.rb
@@ -9,7 +9,7 @@ module Spreedly
           :supports_purchase_via_preauthorization, :supports_offsite_purchase,
           :supports_offsite_authorize, :supports_3dsecure_purchase, :supports_3dsecure_authorize,
           :supports_store, :supports_remove, :supports_general_credit,
-          :supports_fraud_review, :supports_disburse, type: :boolean
+          :supports_fraud_review, type: :boolean
 
     attr_reader :supported_countries, :payment_methods, :auth_modes, :regions
 

--- a/test/unit/gateway_options_test.rb
+++ b/test/unit/gateway_options_test.rb
@@ -68,7 +68,6 @@ class GatewayOptionsTest < Test::Unit::TestCase
       :supports_3dsecure_authorize,
       :supports_store,
       :supports_fraud_review,
-      :supports_disburse
     ].each do |c|
       assert gateway_class.send("#{c}?")
     end

--- a/test/unit/response_stubs/add_gateway_stubs.rb
+++ b/test/unit/response_stubs/add_gateway_stubs.rb
@@ -21,7 +21,6 @@ module AddGatewayStubs
           <supports_3dsecure_authorize type="boolean">true</supports_3dsecure_authorize>
           <supports_store type="boolean">true</supports_store>
           <supports_remove type="boolean">true</supports_remove>
-          <supports_disburse type="boolean">true</supports_disburse>
           <supports_fraud_review type="boolean">true</supports_fraud_review>
         </characteristics>
         <state>retained</state>

--- a/test/unit/response_stubs/find_gateway_stubs.rb
+++ b/test/unit/response_stubs/find_gateway_stubs.rb
@@ -23,7 +23,6 @@ module FindGatewayStubs
           <supports_3dsecure_authorize type="boolean">false</supports_3dsecure_authorize>
           <supports_store type="boolean">false</supports_store>
           <supports_remove type="boolean">false</supports_remove>
-          <supports_disburse type="boolean">false</supports_disburse>
           <supports_fraud_review type="boolean">false</supports_fraud_review>
         </characteristics>
         <credentials>

--- a/test/unit/response_stubs/gateway_options_stubs.rb
+++ b/test/unit/response_stubs/gateway_options_stubs.rb
@@ -78,7 +78,6 @@ module GatewayOptionsStubs
             <supports_3dsecure_authorize type="boolean">true</supports_3dsecure_authorize>
             <supports_store type="boolean">true</supports_store>
             <supports_remove type="boolean">false</supports_remove>
-            <supports_disburse type="boolean">true</supports_disburse>
             <supports_fraud_review type="boolean">true</supports_fraud_review>
           </characteristics>
           <payment_methods>
@@ -130,7 +129,6 @@ module GatewayOptionsStubs
             <supports_3dsecure_authorize type="boolean">false</supports_3dsecure_authorize>
             <supports_store type="boolean">false</supports_store>
             <supports_remove type="boolean">false</supports_remove>
-            <supports_disburse type="boolean">true</supports_disburse>
             <supports_fraud_review type="boolean">false</supports_fraud_review>
           </characteristics>
           <payment_methods>

--- a/test/unit/response_stubs/list_gateways_stubs.rb
+++ b/test/unit/response_stubs/list_gateways_stubs.rb
@@ -22,7 +22,6 @@ module ListGatewaysStubs
             <supports_3dsecure_authorize type="boolean">true</supports_3dsecure_authorize>
             <supports_store type="boolean">true</supports_store>
             <supports_remove type="boolean">true</supports_remove>
-            <supports_disburse type="boolean">true</supports_disburse>
             <supports_fraud_review type="boolean">true</supports_fraud_review>
           </characteristics>
           <credentials>
@@ -58,7 +57,6 @@ module ListGatewaysStubs
             <supports_3dsecure_authorize type="boolean">true</supports_3dsecure_authorize>
             <supports_store type="boolean">true</supports_store>
             <supports_remove type="boolean">true</supports_remove>
-            <supports_disburse type="boolean">true</supports_disburse>
           </characteristics>
           <credentials>
           </credentials>

--- a/test/unit/response_stubs/redact_gateway_stubs.rb
+++ b/test/unit/response_stubs/redact_gateway_stubs.rb
@@ -28,7 +28,6 @@ module RedactGatewayStubs
             <supports_3dsecure_authorize type="boolean">true</supports_3dsecure_authorize>
             <supports_store type="boolean">true</supports_store>
             <supports_remove type="boolean">true</supports_remove>
-            <supports_disburse type="boolean">true</supports_disburse>
           </characteristics>
           <state>redacted</state>
           <payment_methods>


### PR DESCRIPTION
Note that some remote tests fail, but they do so with or without this change, and whether running against prod with disbursements or my local copy without, so I'm gonna assume they're ignorable.

ENRG-7661

Unit: 75 tests, 596 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 97 tests, 258 assertions, 4 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
94.8454% passed