### PR TITLE
Fix a pile of remote test errors

### DIFF
--- a/test/credentials/test_credentials.rb
+++ b/test/credentials/test_credentials.rb
@@ -23,7 +23,7 @@ module Spreedly
     end
 
     def load_personal_creds
-      return {} unless File.exists?(personal_creds_file)
+      return {} unless File.exist?(personal_creds_file)
 
       personal_creds = YAML.load(File.read(personal_creds_file))
       return {} unless personal_creds

--- a/test/remote/remote_add_receiver_test.rb
+++ b/test/remote/remote_add_receiver_test.rb
@@ -25,9 +25,9 @@ class RemoteAddReceiverTest < Test::Unit::TestCase
   end
 
   def test_add_test_receiver
-    receiver = @environment.add_receiver(:test, 'http://testserver.com')
+    receiver = @environment.add_receiver(:test, 'https://testserver.com')
     assert_equal "test", receiver.receiver_type
-    assert_equal 'http://testserver.com', receiver.hostnames
+    assert_equal 'https://testserver.com', receiver.hostnames
   end
 
   def test_need_active_account

--- a/test/remote/remote_deliver_payment_method_test.rb
+++ b/test/remote/remote_deliver_payment_method_test.rb
@@ -38,9 +38,9 @@ class RemoteDeliverPaymentMethodTest < Test::Unit::TestCase
     assert_equal(true, transaction.succeeded?)
     assert_equal(card_token, transaction.payment_method.token)
     assert_equal(receiver_token, transaction.receiver.token)
-    assert_match(/Successfully dumped 0 post variables.*Post body was 109 chars long/m, transaction.response.body)
+    assert_match(/HOST: spreedly-echo.herokuapp.com\nCONNECTION: close/m, transaction.response.body)
     assert_equal('200', transaction.response.status)
-    assert_match(/Server: Apache/m, transaction.response.headers)
+    assert_match(/Server: thin/m, transaction.response.headers)
   end
 
   private
@@ -49,7 +49,7 @@ class RemoteDeliverPaymentMethodTest < Test::Unit::TestCase
   end
 
   def url
-    'http://posttestserver.com/post.php'
+    'https://spreedly-echo.herokuapp.com'
   end
 
   def receiver_test_credentials


### PR DESCRIPTION
This patch fixes a pile of remote test errors. Unfortunately, a couple
still fail for reasons I'm not going to dig more into for the moment.

Unit: 75 tests, 596 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote: 97 tests, 271 assertions, 1 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
97.9381% passed