### PR TITLE
Add support for continue_cachig

### DIFF
--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -279,7 +279,8 @@ module Spreedly
       add_gateway_specific_fields(doc, options)
       add_shipping_address_override(doc, options)
       add_to_doc(doc, options, :order_id, :description, :ip, :email, :merchant_name_descriptor,
-                               :merchant_location_descriptor, :redirect_url, :callback_url)
+                               :merchant_location_descriptor, :redirect_url, :callback_url,
+                               :continue_caching)
     end
 
     def add_gateway_specific_fields(doc, options)

--- a/test/unit/authorize_test.rb
+++ b/test/unit/authorize_test.rb
@@ -67,7 +67,8 @@ class AuthorizeTest < Test::Unit::TestCase
       [ './merchant_name_descriptor', 'TRain' ],
       [ './merchant_location_descriptor', 'British Colombia' ],
       [ './gateway_specific_fields/braintree/customer_id', '1143' ],
-      [ './retain_on_success', 'true' ]
+      [ './retain_on_success', 'true' ],
+      [ './continue_caching', 'true']
   end
 
 
@@ -88,7 +89,8 @@ class AuthorizeTest < Test::Unit::TestCase
       gateway_specific_fields: {
         braintree: { customer_id: "1143" }
       },
-      retain_on_success: true
+      retain_on_success: true,
+      continue_caching: true
     }
   end
 

--- a/test/unit/purchase_test.rb
+++ b/test/unit/purchase_test.rb
@@ -94,7 +94,8 @@ class PurchaseTest < Test::Unit::TestCase
       [ './ip', '183.128.100.103' ],
       [ './merchant_name_descriptor', 'Real Stuff' ],
       [ './merchant_location_descriptor', 'Raleigh' ],
-      [ './retain_on_success', 'true' ]
+      [ './retain_on_success', 'true' ],
+      [ './continue_caching', 'true']
   end
 
 
@@ -112,7 +113,8 @@ class PurchaseTest < Test::Unit::TestCase
       ip: "183.128.100.103",
       merchant_name_descriptor: "Real Stuff",
       merchant_location_descriptor: "Raleigh",
-      retain_on_success: true
+      retain_on_success: true,
+      continue_caching: true
     }
   end
 

--- a/test/unit/verify_test.rb
+++ b/test/unit/verify_test.rb
@@ -57,7 +57,8 @@ class VerifyTest < Test::Unit::TestCase
       [ './ip', '183.128.100.102' ],
       [ './merchant_name_descriptor', 'TRain' ],
       [ './merchant_location_descriptor', 'British Colombia' ],
-      [ './retain_on_success', 'true' ]
+      [ './retain_on_success', 'true' ],
+      [ './continue_caching', 'true']
   end
 
 
@@ -74,7 +75,8 @@ class VerifyTest < Test::Unit::TestCase
       ip: "183.128.100.102",
       merchant_name_descriptor: "TRain",
       merchant_location_descriptor: "British Colombia",
-      retain_on_success: true
+      retain_on_success: true,
+      continue_caching: true
     }
   end
 


### PR DESCRIPTION
Right now the `continue_caching` option is not available. Although you add this field in the options when you make a transaction it is ignored. 

With this fix, it should be able to send `continue_caching` in the options.