### PR TITLE
Expose live API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Here's how you can do it:
 
 ``` ruby
 options = {
-email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2019, last_name: 'Aybara', first_name: 'Perrin', data: "occupation: Blacksmith"
+email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2023, last_name: 'Aybara', first_name: 'Perrin', data: "occupation: Blacksmith"
 }
 transaction = env.add_credit_card(options)
 
@@ -286,7 +286,7 @@ You can also retain the card immediately like so:
 
 ``` ruby
 options = {
-email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2019, last_name: 'Aybara', first_name: 'Perrin', data: "occupation: Blacksmith", retained: true
+email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2023, last_name: 'Aybara', first_name: 'Perrin', data: "occupation: Blacksmith", retained: true
 }
 transaction = env.add_credit_card(options)
 

--- a/lib/spreedly/gateway_class.rb
+++ b/lib/spreedly/gateway_class.rb
@@ -3,7 +3,7 @@ module Spreedly
   class GatewayClass
     include Fields
 
-    field :gateway_type, :name, :homepage, :company_name
+    field :gateway_type, :name, :homepage, :company_name, :display_api_url
     field :supports_purchase, :supports_authorize, :supports_capture, :supports_credit,
           :supports_void, :supports_verify, :supports_reference_purchase,
           :supports_purchase_via_preauthorization, :supports_offsite_purchase,

--- a/test/helpers/creation_helper.rb
+++ b/test/helpers/creation_helper.rb
@@ -23,7 +23,7 @@ module Spreedly
 
     def default_card_deets
       {
-        email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2019,
+        email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2023,
         last_name: 'Aybara', first_name: 'Perrin', retained: true
       }
     end

--- a/test/remote/remote_add_credit_card_test.rb
+++ b/test/remote/remote_add_credit_card_test.rb
@@ -51,7 +51,7 @@ class RemoteAddCreditCardTest < Test::Unit::TestCase
   end
 
   def test_successfull_add_using_full_name
-    t = @environment.add_credit_card(number: '5555555555554444', month: 1, year: 2019, full_name: "Kvothe Jones")
+    t = @environment.add_credit_card(number: '5555555555554444', month: 1, year: 2023, full_name: "Kvothe Jones")
     assert t.succeeded?
     assert_equal "Kvothe", t.payment_method.first_name
     assert_equal "Jones", t.payment_method.last_name
@@ -62,7 +62,7 @@ class RemoteAddCreditCardTest < Test::Unit::TestCase
   private
   def card_deets(options = {})
     {
-      email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2019,
+      email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2023,
       last_name: 'Aybara', first_name: 'Perrin', data: "occupation: Blacksmith"
     }.merge(options)
   end

--- a/test/remote/remote_add_receiver_test.rb
+++ b/test/remote/remote_add_receiver_test.rb
@@ -25,9 +25,9 @@ class RemoteAddReceiverTest < Test::Unit::TestCase
   end
 
   def test_add_test_receiver
-    receiver = @environment.add_receiver(:test, 'https://testserver.com')
+    receiver = @environment.add_receiver(:test, 'http://spreedly-echo.herokuapp.com')
     assert_equal "test", receiver.receiver_type
-    assert_equal 'https://testserver.com', receiver.hostnames
+    assert_equal 'http://spreedly-echo.herokuapp.com', receiver.hostnames
   end
 
   def test_need_active_account

--- a/test/remote/remote_gateway_options_test.rb
+++ b/test/remote/remote_gateway_options_test.rb
@@ -10,7 +10,7 @@ class RemoteGatewayOptionsTest < Test::Unit::TestCase
     gateway_classes = @environment.gateway_options
     braintree = gateway_classes.select { |each| each.name == "Braintree" }.first
     assert_equal "http://www.braintreepaymentsolutions.com/", braintree.homepage
-    assert_equal %w(credit_card third_party_token apple_pay android_pay), braintree.payment_methods
+    assert_equal %w(credit_card third_party_token apple_pay android_pay google_pay), braintree.payment_methods
     assert_equal %w(asia_pacific europe north_america), braintree.regions
     assert_equal %w(orange blue), braintree.auth_modes.map { |e| e.auth_mode_type }
     assert_equal %w(login password), braintree.auth_modes.first.credentials.map { |e| e.name }

--- a/test/remote/remote_update_credit_card_test.rb
+++ b/test/remote/remote_update_credit_card_test.rb
@@ -56,7 +56,7 @@ class RemoteUpdateCreditCardTest < Test::Unit::TestCase
   private
   def card_deets(options = {})
     {
-      email: 'cauthon@wot.com', month: 1, year: 2019,
+      email: 'cauthon@wot.com', month: 1, year: 2023,
       last_name: 'Cauthon', first_name: 'Mat',
       eligible_for_card_updater: 'false'
     }.merge(options)


### PR DESCRIPTION
This will enable us to pick them up for display in Docs, as well as making them available as an informational function for other gem users.