### PR TITLE
Support 3d Secure attempt scenario.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 vendor/ruby
 test/credentials/*.yml
 .ruby-version
+.idea

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -299,7 +299,7 @@ module Spreedly
       add_shipping_address_override(doc, options)
       add_to_doc(doc, options, :order_id, :description, :ip, :email, :merchant_name_descriptor,
                                :merchant_location_descriptor, :redirect_url, :callback_url,
-                               :continue_caching)
+                               :continue_caching, :attempt_3dsecure, :browser_info)
     end
 
     def add_gateway_specific_fields(doc, options)

--- a/lib/spreedly/transactions/auth_purchase.rb
+++ b/lib/spreedly/transactions/auth_purchase.rb
@@ -1,8 +1,7 @@
 module Spreedly
-
   class AuthPurchase < GatewayTransaction
-
-    field :currency_code
+    field :currency_code, :checkout_url, :checkout_form, :redirect_url, :callback_url
+    field :required_action, :challenge_form, :challenge_url, :device_fingerprint_form
     field :amount, type: :integer
 
     attr_reader :payment_method
@@ -11,7 +10,5 @@ module Spreedly
       super
       @payment_method = PaymentMethod.new_from(xml_doc.at_xpath('.//payment_method'))
     end
-
   end
-
 end

--- a/lib/spreedly/transactions/purchase.rb
+++ b/lib/spreedly/transactions/purchase.rb
@@ -1,7 +1,4 @@
 module Spreedly
-
   class Purchase < AuthPurchase
-
   end
-
 end

--- a/test/remote/remote_purchase_test.rb
+++ b/test/remote/remote_purchase_test.rb
@@ -66,6 +66,29 @@ class RemotePurchaseTest < Test::Unit::TestCase
     assert transaction.checkout_url
   end
 
+  def test_3d_secure_attempt_transaction_arguments
+    gateway_token = @environment.add_gateway(:test).token
+    card_token = create_card_on(@environment, number: '4556761029983886', retained: false).token
+
+    transaction = @environment.purchase_on_gateway(gateway_token, card_token, 344,
+                                                   order_id: "8675",
+                                                   description: "SuperDuper",
+                                                   ip: "183.128.100.103",
+                                                   email: "fred@example.com",
+                                                   merchant_name_descriptor: "Real Stuff",
+                                                   merchant_location_descriptor: "Raleigh",
+                                                   retain_on_success: true,
+                                                   redirect_url: "https://example.com/redirect",
+                                                   callback_url: "https://example.com/callback",
+                                                   attempt_3dsecure: true)
+
+    assert_equal "pending", transaction.state
+    assert "https://example.com/callback", transaction.callback_url
+    assert "https://example.com/redirect", transaction.redirect_url
+    assert_equal '', transaction.checkout_url
+    assert transaction.checkout_form.include?("<form action=\"https://core.spreedly.com/test/#{gateway_token}")
+  end
+
   def test_optional_arguments
     gateway_token = @environment.add_gateway(:test).token
     card_token = create_card_on(@environment, retained: false).token

--- a/test/unit/purchase_test.rb
+++ b/test/unit/purchase_test.rb
@@ -55,6 +55,59 @@ class PurchaseTest < Test::Unit::TestCase
     assert_equal '', t.shipping_address.phone_number
   end
 
+  def test_successful_3dsecure_purchase_attempt
+    t = purchase_using(successful_purchase_3dsecure_attempt_response)
+
+    assert_kind_of(Spreedly::Purchase, t)
+    assert_equal 'Btcyks35m4JLSNOs9ymJoNQLjeX', t.token
+    assert_equal 144, t.amount
+    assert t.on_test_gateway?
+    assert_equal Time.parse("2013-07-31 19:46:26 UTC"), t.created_at
+    assert_equal Time.parse("2013-07-31 19:46:32 UTC"), t.updated_at
+    assert_equal 'USD', t.currency_code
+    assert !t.succeeded?
+    assert_equal 'pending', t.state
+    assert_equal 'none', t.required_action
+    assert_equal 'http://challenge_url.test', t.challenge_url
+    assert_equal 'challenge form data', t.challenge_form
+    assert_equal 'device fingerprint form data', t.device_fingerprint_form
+    assert_equal '', t.order_id
+    assert_equal '', t.ip
+    assert_equal '4 Shardblades', t.description
+    assert_equal '', t.merchant_name_descriptor
+    assert_equal '', t.merchant_location_descriptor
+    assert_equal 'YOaCn5a9xRaBTGgmGAWbkgWUuqv', t.gateway_token
+    assert_equal '8xXXIPGXTaPXysDA5OUpgnjTEjK', t.payment_method.token
+    assert_equal "44", t.gateway_transaction_id
+
+    assert t.response.success
+    assert_equal 'Checked enrollment status', t.response.message
+    assert !t.response.pending
+    assert !t.response.fraud_review
+    assert_equal '', t.response.error_code
+    assert_equal Time.parse('2013-07-31T19:46:26Z'), t.response.created_at
+    assert_equal Time.parse('2013-07-31T19:46:27Z'), t.response.updated_at
+
+    assert_equal 'https://example.com/callback_url', t.callback_url
+    assert_equal 'https://example.com/redirect_url', t.redirect_url
+    assert_equal '', t.checkout_url
+
+    assert t.checkout_form.include?('<form action="https://core.spreedly.com/test/1234/auth/1234" method="POST">')
+    assert t.checkout_form.include?('<input name="PaReq" value="" type="hidden"/>')
+    assert t.checkout_form.include?('<input name="MD" value="" type="hidden"/>')
+    assert t.checkout_form.include?('<input name="TermUrl" value="https://core.spreedly.com/transaction/Btcyks35m4JLSNOs9ymJoNQLjeX/redirect" type="hidden"/>')
+    assert t.checkout_form.include?('<input name="Complete" value="Authorize Transaction" type="submit"/>')
+
+    assert_equal '', t.shipping_address.name
+    assert_equal '', t.shipping_address.address1
+    assert_equal '', t.shipping_address.address2
+    assert_equal '', t.shipping_address.city
+    assert_equal '', t.shipping_address.state
+    assert_equal '', t.shipping_address.zip
+    assert_equal '', t.shipping_address.country
+    assert_equal '', t.shipping_address.phone_number
+  end
+
   def test_failed_purchase
     t = purchase_using(failed_purchase_response)
 

--- a/test/unit/response_stubs/purchase_stubs.rb
+++ b/test/unit/response_stubs/purchase_stubs.rb
@@ -241,4 +241,109 @@ module PurchaseStubs
     XML
   end
 
+  def successful_purchase_3dsecure_attempt_response
+    StubResponse.succeeded <<-XML
+      <transaction>
+        <amount type="integer">144</amount>
+        <on_test_gateway type="boolean">true</on_test_gateway>
+        <created_at type="datetime">2013-07-31T19:46:26Z</created_at>
+        <updated_at type="datetime">2013-07-31T19:46:32Z</updated_at>
+        <currency_code>USD</currency_code>
+        <succeeded type="boolean">false</succeeded>
+        <state>pending</state>
+        <token>Btcyks35m4JLSNOs9ymJoNQLjeX</token>
+        <transaction_type>Purchase</transaction_type>
+        <order_id nil="true"/>
+        <ip nil="true"/>
+        <description>4 Shardblades</description>
+        <merchant_name_descriptor nil="true"/>
+        <merchant_location_descriptor nil="true"/>
+        <gateway_specific_fields nil="true"/>
+        <gateway_specific_response_fields nil="true"/>
+        <message key="messages.transaction_pending">Pending</message>
+        <required_action>none</required_action>
+        <challenge_url>http://challenge_url.test</challenge_url>
+        <challenge_form>challenge form data</challenge_form>
+        <device_fingerprint_form>device fingerprint form data</device_fingerprint_form>
+        <gateway_token>YOaCn5a9xRaBTGgmGAWbkgWUuqv</gateway_token>
+        <gateway_transaction_id>44</gateway_transaction_id>
+        <shipping_address>
+          <name nil="true"/>
+          <address1 nil="true"/>
+          <address2 nil="true"/>
+          <city nil="true"/>
+          <state nil="true"/>
+          <zip nil="true"/>
+          <country nil="true"/>
+          <phone_number nil="true"//>
+        </shipping_address>
+        <response>
+          <success type="boolean">true</success>
+          <message>Checked enrollment status</message>
+          <error_code nil="true"/>
+          <checkout_url nil="true"/>
+          <created_at type="datetime">2013-07-31T19:46:26Z</created_at>
+          <updated_at type="datetime">2013-07-31T19:46:27Z</updated_at>
+        </response>
+        <payment_method>
+          <token>8xXXIPGXTaPXysDA5OUpgnjTEjK</token>
+          <created_at type="datetime">2013-07-31T19:46:25Z</created_at>
+          <updated_at type="datetime">2013-07-31T19:46:26Z</updated_at>
+          <email>perrin@wot.com</email>
+          <data nil="true"/>
+          <storage_state>retained</storage_state>
+          <last_four_digits>4444</last_four_digits>
+          <first_six_digits>411111</first_six_digits>
+          <card_type>master</card_type>
+          <first_name>Perrin</first_name>
+          <last_name>Aybara</last_name>
+          <month type="integer">1</month>
+          <year type="integer">2019</year>
+          <address1 nil="true"/>
+          <address2 nil="true"/>
+          <city nil="true"/>
+          <state nil="true"/>
+          <zip nil="true"/>
+          <country nil="true"/>
+          <phone_number nil="true"/>
+          <company>Acme</company>
+          <full_name>Perrin Aybara</full_name>
+          <payment_method_type>credit_card</payment_method_type>
+          <eligible_for_card_updater type="boolean">true</eligible_for_card_updater>
+          <errors>
+          </errors>
+          <verification_value></verification_value>
+          <fingerprint>ac5579920013cc571e506805f1c8f3220eff</fingerprint>
+          <number>XXXX-XXXX-XXXX-4444</number>
+        </payment_method>
+        <api_urls>
+          <callback_conversations>https://core.spreedly.com/v1/callbacks/12345/conversations.xml</callback_conversations>
+        </api_urls>
+        <callback_url>https://example.com/callback_url</callback_url>
+        <redirect_url>https://example.com/redirect_url</redirect_url>
+        <checkout_url nil="true"/>
+        <checkout_form>
+          <![CDATA[
+          <form action="https://core.spreedly.com/test/1234/auth/1234" method="POST">
+            <div>
+              <input name="PaReq" value="" type="hidden"/>
+              <input name="MD" value="" type="hidden"/>
+              <input name="TermUrl" value="https://core.spreedly.com/transaction/Btcyks35m4JLSNOs9ymJoNQLjeX/redirect" type="hidden"/>
+              <input name="Complete" value="Authorize Transaction" type="submit"/>
+            </div>
+          </form>
+          ]]>
+        </checkout_form>
+        <setup_response>
+          <success type="boolean">true</success>
+          <message>Checked enrollment status</message>
+          <error_code nil="true"/>
+          <checkout_url nil="true"/>
+          <created_at type="datetime">2013-07-31T19:46:26Z</created_at>
+          <updated_at type="datetime">2013-07-31T19:46:27Z</updated_at>
+        </setup_response>
+      </transaction>
+    XML
+  end
+
 end


### PR DESCRIPTION
**Context:** Support 3D Secure attempt scenario that was not supported before.

- Add sending `attempt_3dsecure` flag to API
- Add fields to the Purchase transaction to retrieve information returned by the API
- Add unit and remote tests
- Add Rubymine project files folder to `.gitignore`