### PR TITLE
Remove bundler version pinning in dev deps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,20 +2,10 @@ require "bundler/gem_tasks"
 
 require 'rake/testtask'
 
-# Rake::TestTask.new do |t|
-#   t.libs << 'test'
-# end
-
-# desc "Run tests"
-# task :default => :test
-
-
-
-desc "Run the unit test suite"
-task :default => 'test:units'
+desc 'Run the unit test suite'
+task default: 'test:units'
 
 namespace :test do
-
   Rake::TestTask.new(:units) do |t|
     t.pattern = 'test/unit/**/*_test.rb'
     t.libs << 'test'
@@ -27,6 +17,4 @@ namespace :test do
     t.libs << 'test'
     t.verbose = true
   end
-
 end
-

--- a/spreedly.gemspec
+++ b/spreedly.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'nokogiri'
 
-  s.add_development_dependency 'bundler', '~> 1.3'
+  s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'log_buddy'


### PR DESCRIPTION
This removes the overstrictness of bundler version as a dev dependency.
It also cleans up the Rakefile a little bit.