### PR TITLE
Add remote test info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,3 +409,5 @@ There are two rake tasks to help run the tests:
 rake test:remote  # Run remote tests that actually hit the Spreedly site
 rake test:units   # Run unit tests
 ```
+
+To run remote tests you'll need to copy `test/credentials/credentials.yml.example` to `test/credentials/credentials.yml` and update the values of `environment_key` and `access_secret`.

--- a/test/credentials/credentials.yml.example
+++ b/test/credentials/credentials.yml.example
@@ -1,0 +1,5 @@
+# To run remote tests you'll need to copy this file to credentials.yml
+# in the same directory and change the values to match your spreedly environment. 
+
+environment_key: "YOUR-SPREEDLY-ENVIRONMENT-KEY"
+access_secret: "YOUR-SPREEDLY-ACCESS-SECRET"


### PR DESCRIPTION
This adds the necessary info to be able to run remote tests for contributors.
An example file is provided so that folks can just copy a file over and get started
quickly.