### PR TITLE
Support gateway_specific_response_fields

### DIFF
--- a/lib/spreedly/transactions/gateway_transaction.rb
+++ b/lib/spreedly/transactions/gateway_transaction.rb
@@ -6,7 +6,7 @@ module Spreedly
     field :merchant_name_descriptor, :merchant_location_descriptor
     field :on_test_gateway, type: :boolean
 
-    attr_reader :response, :gateway_specific_fields, :shipping_address
+    attr_reader :response, :gateway_specific_fields, :gateway_specific_response_fields, :shipping_address
 
     def initialize(xml_doc)
       super
@@ -14,13 +14,14 @@ module Spreedly
       shipping_address_xml_doc = xml_doc.at_xpath('.//shipping_address')
       @response = response_xml_doc ? Response.new(response_xml_doc) : nil
       @shipping_address = shipping_address_xml_doc ? ShippingAddress.new(shipping_address_xml_doc) : nil
-      @gateway_specific_fields = parse_gateway_specific_fields(xml_doc)
+      @gateway_specific_fields = parse_gateway_fields(xml_doc, './/gateway_specific_fields')
+      @gateway_specific_response_fields = parse_gateway_fields(xml_doc, './/gateway_specific_response_fields')
     end
 
-    def parse_gateway_specific_fields(xml_doc)
+    def parse_gateway_fields(xml_doc, path)
       result = {}
 
-      xml_doc.at_xpath('.//gateway_specific_fields').xpath('*').each do |node|
+      xml_doc.at_xpath(path).xpath('*').each do |node|
         node_name = node.name.to_sym
         if (node.elements.empty?)
           result[node_name] = node.text

--- a/test/unit/authorize_test.rb
+++ b/test/unit/authorize_test.rb
@@ -32,6 +32,7 @@ class AuthorizeTest < Test::Unit::TestCase
     assert_equal "TheName", t.gateway_specific_fields[:litle][:descriptor_name]
     assert_equal "33411441", t.gateway_specific_fields[:litle][:descriptor_phone]
     assert_equal "844", t.gateway_specific_fields[:stripe][:application_fee]
+    assert_equal "credit", t.gateway_specific_response_fields[:stripe][:card_funding]
 
     assert_equal 'Nh2Vw0kAoSQvcJDpK52q4dZlrVJ', t.payment_method.token
     assert_equal 'Forthrast', t.payment_method.last_name

--- a/test/unit/capture_test.rb
+++ b/test/unit/capture_test.rb
@@ -29,6 +29,7 @@ class CaptureTest < Test::Unit::TestCase
     assert_equal 'SoPblCOGDwaRyym68XGWeRiCy1C', t.gateway_token
     assert_equal 'PH6U2tyFWtDSVp88bNW2nnGy5rk', t.reference_token
     assert_equal 'Capture', t.transaction_type
+    assert_equal "credit", t.gateway_specific_response_fields[:stripe][:card_funding]
 
     assert t.response.success
     assert_equal 'Successful capture', t.response.message

--- a/test/unit/response_stubs/authorization_stubs.rb
+++ b/test/unit/response_stubs/authorization_stubs.rb
@@ -26,8 +26,11 @@ module AuthorizationStubs
             <application_fee>844</application_fee>
           </stripe>
         </gateway_specific_fields>
-        <gateway_specific_fields nil="true"/>
-        <gateway_specific_response_fields nil="true"/>
+        <gateway_specific_response_fields>
+          <stripe>
+            <card_funding>credit</card_funding>
+          </stripe>
+        </gateway_specific_response_fields>
         <message key="messages.transaction_succeeded">Succeeded!</message>
         <gateway_token>YjWxOjbpeieXsZFdAsbhM2DFgLe</gateway_token>
         <gateway_transaction_id>44</gateway_transaction_id>

--- a/test/unit/response_stubs/capture_stubs.rb
+++ b/test/unit/response_stubs/capture_stubs.rb
@@ -19,7 +19,11 @@ module CaptureStubs
         <merchant_name_descriptor>My Writeoff Inc.</merchant_name_descriptor>
         <merchant_location_descriptor>Tax Free Zone</merchant_location_descriptor>
         <gateway_specific_fields nil="true"/>
-        <gateway_specific_response_fields nil="true"/>
+        <gateway_specific_response_fields>
+          <stripe>
+            <card_funding>credit</card_funding>
+          </stripe>
+        </gateway_specific_response_fields>
         <message key="messages.transaction_succeeded">Succeeded!</message>
         <gateway_token>SoPblCOGDwaRyym68XGWeRiCy1C</gateway_token>
         <gateway_transaction_id>44</gateway_transaction_id>


### PR DESCRIPTION
This is pulled from https://github.com/spreedly/spreedly-gem/pull/65 - I've rebased the code and removed the merge conflicts. @adamcohen thanks for the contributions!