### PR TITLE
Allow additional params for list_transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Changed
+- @patrickarnett - Modify `list_transactions` and `list_transactions_url` to take `count`, `order`, and `state` arguments in an optional hash.
 
 ## [2.0.19] - 2019-06-07
 ### Added

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -92,8 +92,8 @@ module Spreedly
       Transaction.new_from(xml_doc)
     end
 
-    def list_transactions(since_token = nil, payment_method_token = nil)
-      xml_doc = ssl_get(list_transactions_url(since_token, payment_method_token), headers)
+    def list_transactions(since_token = nil, payment_method_token = nil, options = {})
+      xml_doc = ssl_get(list_transactions_url(since_token, payment_method_token, options), headers)
       Transaction.new_list_from(xml_doc)
     end
 

--- a/lib/spreedly/urls.rb
+++ b/lib/spreedly/urls.rb
@@ -62,11 +62,20 @@ module Spreedly
       "#{base_url}/v1/gateways/#{gateway_token}/store.xml"
     end
 
-    def list_transactions_url(since_token, payment_method_token)
-      since_param = "?since_token=#{since_token}" if since_token
-      return "#{base_url}/v1/transactions.xml#{since_param}" unless payment_method_token
+    def list_transactions_url(since_token, payment_method_token, options = {})
+      options.each do |key, val|
+        options[key.to_sym] = val
+      end
 
-      "#{base_url}/v1/payment_methods/#{payment_method_token}/transactions.xml#{since_param}"
+      params = []
+      params << "since_token=#{since_token}" if since_token
+      params << "count=#{options[:count]}" if options[:count]
+      params << "order=#{options[:order]}" if options[:order]
+      params << "state=#{options[:state]}" if options[:state]
+      param_string = "?#{params.join('&')}" if params.any?
+      return "#{base_url}/v1/transactions.xml#{param_string}" unless payment_method_token
+
+      "#{base_url}/v1/payment_methods/#{payment_method_token}/transactions.xml#{param_string}"
     end
 
     def list_payment_methods_url(since_token)

--- a/test/unit/list_transactions_test.rb
+++ b/test/unit/list_transactions_test.rb
@@ -40,6 +40,18 @@ class ListTransactionsTest < Test::Unit::TestCase
     assert_request_url 'https://core.spreedly.com/v1/payment_methods/SomePaymentMethodToken/transactions.xml?since_token=SinceToken' do
       @environment.list_transactions('SinceToken', 'SomePaymentMethodToken')
     end
+
+    assert_request_url 'https://core.spreedly.com/v1/transactions.xml?order=asc' do
+      @environment.list_transactions(nil, nil, order: :asc)
+    end
+
+    assert_request_url 'https://core.spreedly.com/v1/transactions.xml?since_token=SinceToken&count=10&state=succeeded' do
+      @environment.list_transactions('SinceToken', nil, state: :succeeded, count: 10)
+    end
+
+    assert_request_url 'https://core.spreedly.com/v1/payment_methods/SomePaymentMethodToken/transactions.xml?since_token=SinceToken&count=10&order=asc&state=succeeded' do
+      @environment.list_transactions('SinceToken', 'SomePaymentMethodToken', order: :asc, state: :succeeded, count: 10)
+    end
   end
 
   private


### PR DESCRIPTION
Allow use of `count`, `order`, and `state` params.