### PR TITLE
Remove bundler from dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Removed
+- @jeremywrowe - Remove bundler from dev dependencies
+### Added
 - @jeremywrowe - Add 3D Secure 2 abilities to gateway class
 
 ## [2.0.20] - 2019-06-27

--- a/spreedly.gemspec
+++ b/spreedly.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri'
 
   s.add_development_dependency 'awesome_print'
-  s.add_development_dependency 'bundler'
   s.add_development_dependency 'log_buddy'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This slows bundler down when resolving dependencies and isn't really needed
since most people have bundler installed on their system