### PR TITLE
This adds additional fields to support 3D Secure 2 requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- @jeremywrowe - Support for three_ds_version, three_ds_context, and channel on
+  authorization / purchase
+
 ## [2.0.21] - 2019-07-19
 ### Added
 - @jeremywrowe - Support for Stored Credentials on authorization / purchase

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -302,7 +302,7 @@ module Spreedly
       add_shipping_address_override(doc, options)
       add_to_doc(doc, options, :order_id, :description, :ip, :email, :merchant_name_descriptor,
                                :merchant_location_descriptor, :redirect_url, :callback_url,
-                               :continue_caching, :attempt_3dsecure, :browser_info)
+                               :continue_caching, :attempt_3dsecure, :browser_info, :three_ds_version, :channel)
     end
 
     def add_gateway_specific_fields(doc, options)

--- a/lib/spreedly/transactions/auth_purchase.rb
+++ b/lib/spreedly/transactions/auth_purchase.rb
@@ -2,7 +2,7 @@ module Spreedly
   class AuthPurchase < GatewayTransaction
     field :currency_code, :checkout_url, :checkout_form, :redirect_url, :callback_url
     field :required_action, :challenge_form, :challenge_url, :device_fingerprint_form
-    field :stored_credential_initiator, :stored_credential_reason_type
+    field :stored_credential_initiator, :stored_credential_reason_type, :three_ds_context
     field :amount, type: :integer
 
     attr_reader :payment_method

--- a/test/remote/remote_purchase_test.rb
+++ b/test/remote/remote_purchase_test.rb
@@ -87,8 +87,8 @@ class RemotePurchaseTest < Test::Unit::TestCase
   def test_3d_secure_attempt_transaction_arguments
     gateway_token = @environment.add_gateway(:test).token
     card_token = create_card_on(@environment, number: '4556761029983886', retained: false).token
-
-    transaction = @environment.purchase_on_gateway(gateway_token, card_token, 344,
+    browser_info = "eyJ3aWR0aCI6MzAwOCwiaGVpZ2h0IjoxNjkyLCJkZXB0aCI6MjQsInRpbWV6b25lIjoyNDAsInVzZXJfYWdlbnQiOiJNb3ppbGxhLzUuMCAoTWFjaW50b3NoOyBJbnRlbCBNYWMgT1MgWCAxMC4xNDsgcnY6NjguMCkgR2Vja28vMjAxMDAxMDEgRmlyZWZveC82OC4wIiwiamF2YSI6ZmFsc2UsImxhbmd1YWdlIjoiZW4tVVMiLCJhY2NlcHRfaGVhZGVyIjoidGV4dC9odG1sLGFwcGxpY2F0aW9uL3hodG1sK3htbCxhcHBsaWNhdGlvbi94bWwifQ=="
+    transaction = @environment.purchase_on_gateway(gateway_token, card_token, 3004,
                                                    order_id: "8675",
                                                    description: "SuperDuper",
                                                    ip: "183.128.100.103",
@@ -98,13 +98,13 @@ class RemotePurchaseTest < Test::Unit::TestCase
                                                    retain_on_success: true,
                                                    redirect_url: "https://example.com/redirect",
                                                    callback_url: "https://example.com/callback",
-                                                   attempt_3dsecure: true)
+                                                   browser_info: browser_info,
+                                                   attempt_3dsecure: true,
+                                                   three_ds_version: "2.0")
 
     assert_equal "pending", transaction.state
-    assert "https://example.com/callback", transaction.callback_url
-    assert "https://example.com/redirect", transaction.redirect_url
-    assert_equal '', transaction.checkout_url
-    assert transaction.checkout_form.include?("<form action=\"https://core.spreedly.com/test/#{gateway_token}")
+    assert_equal "https://example.com/redirect", transaction.redirect_url
+    assert_equal "device_fingerprint", transaction.required_action
   end
 
   def test_optional_arguments

--- a/test/unit/authorize_test.rb
+++ b/test/unit/authorize_test.rb
@@ -28,6 +28,7 @@ class AuthorizeTest < Test::Unit::TestCase
     assert_equal 'Tax Free Zone', t.merchant_location_descriptor
     assert_equal 'YjWxOjbpeieXsZFdAsbhM2DFgLe', t.gateway_token
     assert_equal "44", t.gateway_transaction_id
+    assert_equal "three-ds-context", t.three_ds_context
     assert_equal "Authorization", t.transaction_type
     assert_equal "TheName", t.gateway_specific_fields[:litle][:descriptor_name]
     assert_equal "33411441", t.gateway_specific_fields[:litle][:descriptor_phone]

--- a/test/unit/purchase_test.rb
+++ b/test/unit/purchase_test.rb
@@ -30,6 +30,7 @@ class PurchaseTest < Test::Unit::TestCase
     assert_equal '8xXXIPGXTaPXysDA5OUpgnjTEjK', t.payment_method.token
     assert_equal "44", t.gateway_transaction_id
     assert_equal "Purchase", t.transaction_type
+    assert_equal "three-ds-context", t.three_ds_context
 
     assert t.response.success
     assert_equal 'Successful purchase', t.response.message

--- a/test/unit/response_stubs/authorization_stubs.rb
+++ b/test/unit/response_stubs/authorization_stubs.rb
@@ -17,6 +17,7 @@ module AuthorizationStubs
         <description>LotsOCoffee</description>
         <merchant_name_descriptor>My Writeoff Inc.</merchant_name_descriptor>
         <merchant_location_descriptor>Tax Free Zone</merchant_location_descriptor>
+        <three_ds_context>three-ds-context</three_ds_context>
         <gateway_specific_fields>
           <litle>
             <descriptor_name>TheName</descriptor_name>

--- a/test/unit/response_stubs/purchase_stubs.rb
+++ b/test/unit/response_stubs/purchase_stubs.rb
@@ -22,6 +22,7 @@ module PurchaseStubs
         <message key="messages.transaction_succeeded">Succeeded!</message>
         <gateway_token>YOaCn5a9xRaBTGgmGAWbkgWUuqv</gateway_token>
         <gateway_transaction_id>44</gateway_transaction_id>
+        <three_ds_context>three-ds-context</three_ds_context>
         <shipping_address>
           <name nil="true"/>
           <address1 nil="true"/>


### PR DESCRIPTION
Adds request attributes on auth and purchase - `:three_ds_version` and
`:channel`.  It also adds a response fields of `:three_ds_context` on auth and
purchase responses.