### PR TITLE
Add Environment#complete_transaction to support 3ds2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [Unreleased]
+### Added
+- @jeremywrowe - Add 3D Secure 2 complete transaction
 
 ## [2.0.23] - 2019-08-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ env.purchase_on_gateway(gateway_token, payment_method_token, amount,
                        )
 ```
 
+#### Complete a transaction (3DS 2)
+
+```ruby
+env.complete_transaction(transaction_token)
+```
+
 #### Retain on success
 Retain a payment method automatically if the purchase, verify, or authorize transaction succeeded.  Saves you a separate call to retain:
 
@@ -321,7 +327,6 @@ You can get the full list of supported receivers like so:
 ``` ruby
 env.receiver_options
 ```
-
 
 ## Error Handling
 

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -49,6 +49,10 @@ module Spreedly
       api_post(authorize_url(gateway_token), body)
     end
 
+    def complete_transaction(transaction_token)
+      api_post(complete_transaction_url(transaction_token), '')
+    end
+
     def verify_on_gateway(gateway_token, payment_method_token, options = {})
       body = verify_body(payment_method_token, options)
       api_post(verify_url(gateway_token), body)

--- a/lib/spreedly/urls.rb
+++ b/lib/spreedly/urls.rb
@@ -12,6 +12,10 @@ module Spreedly
       "#{base_url}/v1/transactions/#{transaction_token}/transcript"
     end
 
+    def complete_transaction_url(token)
+      "#{base_url}/v1/transactions/#{token}/complete.xml"
+    end
+
     def find_gateway_url(token)
       "#{base_url}/v1/gateways/#{token}.xml"
     end

--- a/test/helpers/creation_helper.rb
+++ b/test/helpers/creation_helper.rb
@@ -1,16 +1,19 @@
 
 module Spreedly
-
   module CreationHelper
-
     def create_card_on(environment, options = {})
-      deets = default_card_deets.merge(options)
-      environment.add_credit_card(deets).payment_method
+      options = default_card_options.merge(options)
+      environment.add_credit_card(options).payment_method
     end
 
     def create_failed_card_on(environment, options = {})
-      deets = default_card_deets.merge(number: '4012888888881881').merge(options)
-      environment.add_credit_card(deets).payment_method
+      options = default_card_options.merge(number: '4012888888881881').merge(options)
+      environment.add_credit_card(options).payment_method
+    end
+
+    def create_threeds_2_card_on(environment, options = {})
+      options = default_card_options.merge(number: '4556761029983886').merge(options)
+      environment.add_credit_card(options).payment_method
     end
 
     def create_sprel_on(environment)
@@ -21,7 +24,7 @@ module Spreedly
 
     private
 
-    def default_card_deets
+    def default_card_options
       {
         email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2023,
         last_name: 'Aybara', first_name: 'Perrin', retained: true

--- a/test/remote/remote_complete_test.rb
+++ b/test/remote/remote_complete_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class RemoteCompleteTransactionTest < Test::Unit::TestCase
+  def setup
+    @environment = Spreedly::Environment.new(remote_test_environment_key, remote_test_access_secret)
+  end
+
+  def test_successful_complete_a_3ds_transaction
+    gateway_token = @environment.add_gateway(:test).token
+    card_token = create_threeds_2_card_on(@environment).token
+    base64_encoded_browser_info = "eyJ3aWR0aCI6MTY4MCwiaGVpZ2h0IjoxMDUwLCJkZXB0aCI6MjQsInRpbWV6b25lIjoyNDAsInVzZXJfYWdlbnQiOiJNb3ppbGxhLzUuMCAoTWFjaW50b3NoOyBJbnRlbCBNYWMgT1MgWCAxMF8xNF80KSBBcHBsZVdlYktpdC82MDUuMS4xNSAoS0hUTUwsIGxpa2UgR2Vja28pIFZlcnNpb24vMTIuMSBTYWZhcmkvNjA1LjEuMTUiLCJqYXZhIjp0cnVlLCJsYW5ndWFnZSI6ImVuLVVTIn0="
+    purchase = @environment.purchase_on_gateway(
+      gateway_token,
+      card_token,
+      3003,
+      browser_info: base64_encoded_browser_info,
+      three_ds_version: '2.0',
+      redirect_url: 'https://example.com/redirect',
+      callback_url: 'https://example.com/callback',
+      attempt_3dsecure: true
+    )
+    assert_equal 'pending', purchase.state
+
+    complete_transaction = @environment.complete_transaction(purchase.token)
+    assert_equal 'succeeded', complete_transaction.state
+  end
+end


### PR DESCRIPTION
This adds a new method to environment `complete_transaction`. It's intended to
be used to complete a transaction throughout the 3DS 2 lifecycle.

Example usage:

```rb
purchase = environment.purchase_on_gateway(....)
environment.complete_transaction(purchase.token)
```