### PR TITLE
Support updating `eligible_for_card_updater` on expired cards

### DIFF
--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -271,7 +271,8 @@ module Spreedly
       build_xml_request('payment_method') do |doc|
         add_to_doc(doc, options, :email, :month, :full_name, :first_name, :last_name, :year,
                    :address1, :address2, :city, :state, :zip, :country, :phone_number,
-                   :eligible_for_card_updater)
+                   :eligible_for_card_updater, :allow_expired_date, :allow_blank_date,
+                   :allow_blank_name)
       end
     end
 

--- a/lib/spreedly/payment_methods/credit_card.rb
+++ b/lib/spreedly/payment_methods/credit_card.rb
@@ -5,6 +5,9 @@ module Spreedly
     field :number, :last_four_digits, :first_six_digits, :card_type, :verification_value
     field :address1, :address2, :city, :state, :zip, :country, :phone_number, :company, :fingerprint
     field :eligible_for_card_updater, type: :boolean
+    field :allow_expired_date, type: :boolean
+    field :allow_blank_date, type: :boolean
+    field :allow_blank_name, type: :boolean
   end
 
 end

--- a/test/unit/update_credit_card_test.rb
+++ b/test/unit/update_credit_card_test.rb
@@ -36,7 +36,10 @@ class UpdateCreditCreditCardTest < Test::Unit::TestCase
       [ './state', 'Mokia' ],
       [ './zip', '1122' ],
       [ './country', 'Free Kingdoms' ],
-      [ './phone_number', '81Ab' ]
+      [ './phone_number', '81Ab' ],
+      [ './allow_expired_date', 'true' ],
+      [ './allow_blank_date', 'true' ],
+      [ './allow_blank_name', 'true' ]
   end
 
   private
@@ -50,7 +53,8 @@ class UpdateCreditCreditCardTest < Test::Unit::TestCase
       email: 'leavenworth@free.com', month: 3, year: 2021,
       last_name: 'Smedry', first_name: 'Leavenworth',
       address1: '10 Dragon Lane', address2: 'Suite 9', city: 'Tuki Tuki', state: 'Mokia',
-      zip: '1122', country: 'Free Kingdoms', phone_number: '81Ab'
+      zip: '1122', country: 'Free Kingdoms', phone_number: '81Ab',
+      allow_expired_date: true, allow_blank_date: true, allow_blank_name: true
     }
   end
 


### PR DESCRIPTION
It's currently not possible to update an expired payment method, because the necessary attributes are not defined.

This PR adds support for the the `allow_expired_date`, `allow_blank_date` and `allow_blank_name` attributes as specified in the [Spreedly API documentation for payment_method#update](https://docs.spreedly.com/reference/api/v1/#update34).