### PR TITLE
Add MITFW support flag to Spreedly Gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.24] - 2021-07-12
+### Added
+- @almalee24 - Add MIT Framework support flag, supports_populate_mit_fields  
+
 ## [2.0.24] - 2019-08-21
 ### Added
 - @jeremywrowe - Add 3D Secure 2 complete transaction

--- a/lib/spreedly/gateway_class.rb
+++ b/lib/spreedly/gateway_class.rb
@@ -11,7 +11,8 @@ module Spreedly
           :supports_3dsecure_2_purchase, :supports_3dsecure_2_authorize,
           :supports_3dsecure_2_mpi_purchase, :supports_3dsecure_2_mpi_authorize,
           :supports_store, :supports_remove, :supports_general_credit,
-          :supports_fraud_review, type: :boolean
+          :supports_fraud_review, type: :boolean,
+          :supports_populate_mit_fields 
 
     attr_reader :supported_countries, :payment_methods, :auth_modes, :regions
 

--- a/test/unit/gateway_options_test.rb
+++ b/test/unit/gateway_options_test.rb
@@ -68,6 +68,7 @@ class GatewayOptionsTest < Test::Unit::TestCase
       :supports_general_credit,
       :supports_offsite_authorize,
       :supports_offsite_purchase,
+      :supports_populate_mit_fields,
       :supports_purchase,
       :supports_purchase_via_preauthorization,
       :supports_reference_purchase,


### PR DESCRIPTION
Added supports_populate_mit_fields to Spreedly Gem so that Docs can correctly generate gateway fact sheets to indicate MITFW support

ECS-1922