### PR TITLE
Allow posting of the sca_authentication_parameters

### DIFF
--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -304,9 +304,16 @@ module Spreedly
     def add_extra_options_for_basic_ops(doc, options)
       add_gateway_specific_fields(doc, options)
       add_shipping_address_override(doc, options)
+      add_sca_authentication_parameters(doc, options)
       add_to_doc(doc, options, :order_id, :description, :ip, :email, :merchant_name_descriptor,
                                :merchant_location_descriptor, :redirect_url, :callback_url,
-                               :continue_caching, :attempt_3dsecure, :browser_info, :three_ds_version, :channel)
+                               :continue_caching, :attempt_3dsecure, :browser_info, :three_ds_version, :channel,
+                               :sca_provider_key)
+    end
+
+    def add_sca_authentication_parameters(doc, options)
+      return unless options[:sca_authentication_parameters].kind_of?(Hash)
+      doc << "<sca_authentication_parameters>#{xml_for_hash(options[:sca_authentication_parameters])}</sca_authentication_parameters>"
     end
 
     def add_gateway_specific_fields(doc, options)

--- a/test/credentials/credentials.yml.example
+++ b/test/credentials/credentials.yml.example
@@ -3,3 +3,4 @@
 
 environment_key: "YOUR-SPREEDLY-ENVIRONMENT-KEY"
 access_secret: "YOUR-SPREEDLY-ACCESS-SECRET"
+sca_provider_key: "YOUR-SPREEDLY-SCA-PROVIDER-KEY"

--- a/test/credentials/test_credentials.rb
+++ b/test/credentials/test_credentials.rb
@@ -9,6 +9,10 @@ module Spreedly
       remote_creds["access_secret"]
     end
 
+    def remote_test_sca_provider_key
+      remote_creds["sca_provider_key"]
+    end
+
     private
     def remote_creds
       @@remote_creds ||= load_creds

--- a/test/remote/remote_purchase_test.rb
+++ b/test/remote/remote_purchase_test.rb
@@ -107,6 +107,57 @@ class RemotePurchaseTest < Test::Unit::TestCase
     assert_equal "device_fingerprint", transaction.required_action
   end
 
+  def test_3d_secure_global_challenge_transaction_arguments
+    gateway_token = @environment.add_gateway(:test).token
+    card_token = create_card_on(@environment, number: '4556761029983886', retained: false).token
+    browser_info = "eyJ3aWR0aCI6MzAwOCwiaGVpZ2h0IjoxNjkyLCJkZXB0aCI6MjQsInRpbWV6b25lIjoyNDAsInVzZXJfYWdlbnQiOiJNb3ppbGxhLzUuMCAoTWFjaW50b3NoOyBJbnRlbCBNYWMgT1MgWCAxMC4xNDsgcnY6NjguMCkgR2Vja28vMjAxMDAxMDEgRmlyZWZveC82OC4wIiwiamF2YSI6ZmFsc2UsImxhbmd1YWdlIjoiZW4tVVMiLCJhY2NlcHRfaGVhZGVyIjoidGV4dC9odG1sLGFwcGxpY2F0aW9uL3hodG1sK3htbCxhcHBsaWNhdGlvbi94bWwifQ=="
+    transaction = @environment.purchase_on_gateway(gateway_token, card_token, 3004,
+      sca_provider_key: remote_test_sca_provider_key,
+      sca_authentication_parameters: {
+        test_scenario: {
+          scenario: "challenge" # returns a pending transaction that must go through a challenge flow using Spreedly’s iFrame helpers
+        }
+      },
+      browser_info: browser_info
+    )
+    assert !transaction.succeeded?
+    assert_equal "pending", transaction.state
+    assert_equal "challenge", transaction.required_action
+    assert_match "form action", transaction.challenge_form
+  end
+
+  def test_3d_secure_global_authenticated_transaction_arguments
+    gateway_token = @environment.add_gateway(:test).token
+    card_token = create_card_on(@environment, number: '4556761029983886', retained: false).token
+    browser_info = "eyJ3aWR0aCI6MzAwOCwiaGVpZ2h0IjoxNjkyLCJkZXB0aCI6MjQsInRpbWV6b25lIjoyNDAsInVzZXJfYWdlbnQiOiJNb3ppbGxhLzUuMCAoTWFjaW50b3NoOyBJbnRlbCBNYWMgT1MgWCAxMC4xNDsgcnY6NjguMCkgR2Vja28vMjAxMDAxMDEgRmlyZWZveC82OC4wIiwiamF2YSI6ZmFsc2UsImxhbmd1YWdlIjoiZW4tVVMiLCJhY2NlcHRfaGVhZGVyIjoidGV4dC9odG1sLGFwcGxpY2F0aW9uL3hodG1sK3htbCxhcHBsaWNhdGlvbi94bWwifQ=="
+    transaction = @environment.purchase_on_gateway(gateway_token, card_token, 3004,
+      sca_provider_key: remote_test_sca_provider_key,
+      sca_authentication_parameters: {
+        test_scenario: {
+          scenario: "authenticated" # frictionless
+        }
+      },
+      browser_info: browser_info
+    )
+    assert transaction.succeeded?
+  end
+
+  def test_3d_secure_global_not_authenticated_transaction_arguments
+    gateway_token = @environment.add_gateway(:test).token
+    card_token = create_card_on(@environment, number: '4556761029983886', retained: false).token
+    browser_info = "eyJ3aWR0aCI6MzAwOCwiaGVpZ2h0IjoxNjkyLCJkZXB0aCI6MjQsInRpbWV6b25lIjoyNDAsInVzZXJfYWdlbnQiOiJNb3ppbGxhLzUuMCAoTWFjaW50b3NoOyBJbnRlbCBNYWMgT1MgWCAxMC4xNDsgcnY6NjguMCkgR2Vja28vMjAxMDAxMDEgRmlyZWZveC82OC4wIiwiamF2YSI6ZmFsc2UsImxhbmd1YWdlIjoiZW4tVVMiLCJhY2NlcHRfaGVhZGVyIjoidGV4dC9odG1sLGFwcGxpY2F0aW9uL3hodG1sK3htbCxhcHBsaWNhdGlvbi94bWwifQ=="
+    transaction = @environment.purchase_on_gateway(gateway_token, card_token, 3004,
+      sca_provider_key: remote_test_sca_provider_key,
+      sca_authentication_parameters: {
+        test_scenario: {
+          scenario: "not_authenticated" # immediate failure
+        }
+      },
+      browser_info: browser_info
+    )
+    assert !transaction.succeeded?
+  end
+
   def test_optional_arguments
     gateway_token = @environment.add_gateway(:test).token
     card_token = create_card_on(@environment, retained: false).token


### PR DESCRIPTION
This adds the basics to allow the different SCA test scenarios through. 