### PR TITLE
Updated Spreedly::Environment for Google Pay

### DIFF
--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -174,11 +174,20 @@ module Spreedly
       build_xml_request('transaction') do |doc|
         doc.amount amount
         doc.currency_code(options[:currency_code] || currency_code)
-        doc.payment_method_token(payment_method_token)
+        add_payment_token(doc, payment_method_token)
         add_to_doc(doc, options, :retain_on_success)
         add_to_doc(doc, options, :stored_credential_initiator)
         add_to_doc(doc, options, :stored_credential_reason_type)
         add_extra_options_for_basic_ops(doc, options)
+      end
+    end
+
+    def add_payment_token(doc, payment_method_token)
+      payment_method_token = payment_method_token.gsub(/\n/, '')
+      if payment_method_token.include?('<google_pay>')
+        doc << payment_token.to_xml
+      else # if credit card
+        doc.payment_method_token(payment_method_token)
       end
     end
 

--- a/test/unit/payment_token_stubs/google_payment_token_stubs.rb
+++ b/test/unit/payment_token_stubs/google_payment_token_stubs.rb
@@ -1,0 +1,13 @@
+module GooglePaymentTokenStubs
+  def google_pay_token
+    token = <<~TEXT
+      <google_pay>
+        <payment_data>
+          <![CDATA[{"signature":"MEUCIA6SGVRwhOyeYRkeDUUNwB/kGtyfQAlOsg7NZydT17u/AiEA48BhWGQEF1EbEU0J+m8eSK3rTfhok9QqpiFVbME+Ky0\u003d","protocolVersion":"ECv1","signedMessage":"{\"encryptedMessage\":\"3v4IcT/eovIDP2WF8iRUy4qWQnE9Cx0vQxIZ5f9i3Emv3Tzs1AzvB7cxXhxrjp9FVIzdOwsZAPAsm03gvoYq8Xdr70XvrVRd2MFwQhMC7IV/uEsthw4JsR8oCkbI5v/zqhu2B+JodFgavNliHcpKBgijy2D6bpx7jXEkM39M/L4oBObFxFrhVSLA1GjOV6A5gLAXNXt0ffkCYekihqAyJrWlk3sCBDCF5SUiAKEIOIZtzZLgusxjVp6ufZHOHm/53uhAi6JWSJ1E6G5aaYGtULYdwgURHtxN5OIzQPYlEGctaQd5tgfCsBFfGkYyN1GRNgclbaLzAfk/Jn7/6IVKuV0ol3xubTcnjGTZXwtTjiEyYDoz1yVqB9ViMmJa55L6nBtbbAkcNEgAi7dPnrbvBGEP7QWsNT9D71g8SWrlRTCYUAOyuamaQhofG4ul1IVjmltdAy2BHBWpqgJnR9kczydQyE7uDiqhSC1/0eG8GCGIqoi8XfOioGXfMyLZ1p2ZcNK9ECjzUrH/edrwgtShxgWuWMwQTM4DQlVTAA/R4DVs192YWZcc7jm5wLqZ0+XEaPuighJM1Ps1Egeccg\\u003d\\u003d\",\"ephemeralPublicKey\":\"BA2SvF9BdCX7Tl1wwRkyLzTfqhctobhZgSugC9Cz77XNUCBOBMfFyJQt506PUs89D6IJZZfOkZopy0shRF9Uph4\\u003d\",\"tag\":\"Uhin1BE7KAuuiam7eEQFimRUDd9Xn6tZc2fClTpfrXQ\\u003d\"}"}
+]]>
+        </payment_data>
+        <test_card_number>4111111111111111</test_card_number> <!-- Remove in production -->
+      </google_pay>
+    TEXT
+  end
+end

--- a/test/unit/purchase_test.rb
+++ b/test/unit/purchase_test.rb
@@ -1,9 +1,11 @@
 require 'test_helper'
 require 'unit/response_stubs/purchase_stubs'
+require 'unit/payment_token_stubs/google_payment_token_stubs'
 
 class PurchaseTest < Test::Unit::TestCase
 
   include PurchaseStubs
+  include GooglePaymentTokenStubs
 
   def setup
     @environment = Spreedly::Environment.new("key", "secret")
@@ -153,6 +155,26 @@ class PurchaseTest < Test::Unit::TestCase
       [ './continue_caching', 'true']
   end
 
+  def test_request_body_params_for_google_pay
+    body = get_request_body(successful_purchase_response) do
+      @environment.purchase_on_gateway("TheGatewayToken", google_pay_token, 2001, all_possible_options)
+    end
+
+    transaction = body.xpath('./transaction')
+    assert_xpaths_in transaction,
+      [ './amount', '2001' ],
+      [ './currency_code', 'EUR' ],
+      [ './payment_method_token', '' ],
+      [ './order_id', '8675' ],
+      [ './description', 'SuperDuper' ],
+      [ './ip', '183.128.100.103' ],
+      [ './merchant_name_descriptor', 'Real Stuff' ],
+      [ './merchant_location_descriptor', 'Raleigh' ],
+      [ './retain_on_success', 'true' ],
+      [ './continue_caching', 'true']
+
+    assert body.to_s.include?(google_pay_token)
+  end
 
   private
   def purchase_using(response)


### PR DESCRIPTION
This commit updates the logic in auth_purchase_body to handle payment tokens related to google pay.

It does this by looking at the payment token string and if it has the word google_pay we know it is a google payment token.