### PR TITLE
Add User-Agent header and remove unused options code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-## [2.0.25] - 2023-03-24
+## [2.0.26] - 2023-03-24
 ### Changed
 - @jknipp - Update the gateway options url to use `GET /v1/gateways_options.xml` instead of `OPTIONS /v1/gateways.xml`
 
-## [2.0.24] - 2021-07-12
+## [2.0.25] - 2021-07-12
 ### Added
 - @almalee24 - Add MIT Framework support flag, supports_populate_mit_fields
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [2.0.27] - 2023-03-27
+### Changed
+- @jknipp - Add User-Agent header to requests
+- @jknipp - Remove unused options request logic
+
 ## [2.0.26] - 2023-03-24
 ### Changed
 - @jknipp - Update the gateway options url to use `GET /v1/gateways_options.xml` instead of `OPTIONS /v1/gateways.xml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [2.0.25] - 2023-03-24
+### Changed
+- @jknipp - Update the gateway options url to use `GET /v1/gateways_options.xml` instead of `OPTIONS /v1/gateways.xml`
 
 ## [2.0.24] - 2021-07-12
 ### Added
-- @almalee24 - Add MIT Framework support flag, supports_populate_mit_fields  
+- @almalee24 - Add MIT Framework support flag, supports_populate_mit_fields
 
 ## [2.0.24] - 2019-08-21
 ### Added

--- a/lib/spreedly/connection.rb
+++ b/lib/spreedly/connection.rb
@@ -20,8 +20,6 @@ module Spreedly
         http.put(endpoint.request_uri, body, headers)
       when :delete
         http.delete(endpoint.request_uri, headers)
-      when :options
-        http.request(OptionsWithResponseBody.new(endpoint.request_uri, headers))
       else
         raise ArgumentError, "Unsupported request method #{method.to_s.upcase}"
       end
@@ -43,12 +41,6 @@ module Spreedly
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     end
 
-  end
-
-  class OptionsWithResponseBody < Net::HTTPRequest
-    METHOD = 'OPTIONS'
-    REQUEST_HAS_BODY = false
-    RESPONSE_HAS_BODY = true
   end
 
 end

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -166,7 +166,8 @@ module Spreedly
     def headers
       {
         'Authorization' => ('Basic ' + Base64.strict_encode64("#{@key}:#{@access_secret}").chomp),
-        'Content-Type' => 'text/xml'
+        'Content-Type' => 'text/xml',
+        'User-Agent' => "spreedly-gem/#{Spreedly::VERSION}"
       }
     end
 

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -118,7 +118,7 @@ module Spreedly
     end
 
     def gateway_options
-      xml_doc = ssl_options(gateway_options_url)
+      xml_doc = ssl_get(gateway_options_url, headers)
       GatewayClass.new_list_from(xml_doc)
     end
 

--- a/lib/spreedly/ssl_requester.rb
+++ b/lib/spreedly/ssl_requester.rb
@@ -16,10 +16,6 @@ module Spreedly
       ssl_request(:put, endpoint, body, headers)
     end
 
-    def ssl_options(endpoint)
-      ssl_request(:options, endpoint, nil, {})
-    end
-
     private
 
     def ssl_request(method, endpoint, body, headers, options = {})

--- a/lib/spreedly/urls.rb
+++ b/lib/spreedly/urls.rb
@@ -91,7 +91,7 @@ module Spreedly
     end
 
     def gateway_options_url
-      "#{base_url}/v1/gateways.xml"
+      "#{base_url}/v1/gateways_options.xml"
     end
 
     def add_gateway_url

--- a/lib/spreedly/version.rb
+++ b/lib/spreedly/version.rb
@@ -1,3 +1,3 @@
 module Spreedly
-  VERSION = "2.0.24"
+  VERSION = "2.0.26"
 end

--- a/lib/spreedly/version.rb
+++ b/lib/spreedly/version.rb
@@ -1,3 +1,3 @@
 module Spreedly
-  VERSION = "2.0.26"
+  VERSION = "2.0.27"
 end

--- a/test/remote/remote_gateway_options_test.rb
+++ b/test/remote/remote_gateway_options_test.rb
@@ -10,7 +10,7 @@ class RemoteGatewayOptionsTest < Test::Unit::TestCase
     gateway_classes = @environment.gateway_options
     braintree = gateway_classes.select { |each| each.name == "Braintree" }.first
     assert_equal "http://www.braintreepaymentsolutions.com/", braintree.homepage
-    assert_equal %w(credit_card third_party_token apple_pay android_pay google_pay), braintree.payment_methods
+    assert (%w(credit_card third_party_token apple_pay android_pay google_pay) - braintree.payment_methods).empty?
     assert_equal %w(asia_pacific europe north_america), braintree.regions
     assert_equal %w(orange blue), braintree.auth_modes.map { |e| e.auth_mode_type }
     assert_equal %w(login password), braintree.auth_modes.first.credentials.map { |e| e.name }


### PR DESCRIPTION
- Add the User-Agent header to all requests so that we can track usage of the spreedly gem by version going forward.
- Remove remove unused to perform an 'OPTIONS' requests.